### PR TITLE
resolve evidence validation

### DIFF
--- a/paper-wiki/SKILL.md
+++ b/paper-wiki/SKILL.md
@@ -2,184 +2,1357 @@
 name: paper-wiki
 description: |
   Academic literature management and survey system. Supports journal organization,
-  tag management, literature survey report generation, review-paper/literature-review
-  drafting, and submission recommendation. Trigger: user mentions "literature",
-  "paper", "survey", "review paper", "literature review", "journal", "submission",
-  "paper-wiki", or requests scan/report/recommendation/review on an initialized vault.
+  tag management, literature survey report generation, and submission recommendation.
+  Trigger: user mentions "literature", "paper", "survey", "journal", "submission",
+  "paper-wiki", or requests scan/report/recommendation on an initialized vault.
 ---
 
-# paper-wiki - Academic Literature Survey Skill
+# paper-wiki — Academic Literature Survey Skill
 
-Manage a local Markdown literature vault: scan, organize, ingest, tag, generate survey reports,
-read individual papers, search academic web sources, and recommend submission targets.
+> Manage a local Markdown literature vault. Scan, organize, tag, survey, and recommend — all from one skill.
+
+## What This Skill Does
+
+paper-wiki turns a folder of paper Markdown files into a structured, indexed literature vault with:
+
+- **Journal organization**: auto-sort papers into `paper/{direction}/{journal_abbr}/`
+- **Tag management**: multi-dimensional tagging (task, method, dataset, domain, signal, etc.)
+- **Survey reports**: journal reports, direction reports, method/dataset stats, idea novelty surveys
+- **Submission guidance**: journal scoring, revision suggestions based on local literature evidence
 
 ## Quick Start
 
-- "Initialize vault" / "初始化文献库" -> run **init**
-- "Scan papers" / "扫描文献" -> run **scan-organize**
-- "Ingest papers" / "入库" -> run **ingest**
-- "Generate RESS journal report" / "RESS期刊报告" -> run **journal-report**
-- "Write a literature review" / "方向综述" -> run **direction-review**
-- "Read this paper" / "单篇文献精读" -> run **paper-read**
-- "Web find papers" / "联网检索" -> run **web-find**
-- "Recommend submission target" / "投稿推荐" -> run **submission-recommend**
-- "Vault status" / "文献库状态" -> run **status**
+- "Initialize vault" → **init**
+- "Scan Battery papers" → **scan-organize**
+- "Generate RESS journal report" → **journal-report**
+- "Recommend submission target for my paper" → **submission-recommend**
 
-Use this file as the always-loaded entrypoint. Read reference files only when the user's task needs
-that detail.
+---
 
-## Reference Map / 按需读取
+## Configuration
 
-All detailed references are one level deep under `references/`.
+All config is in `config.json` at project root. Key fields:
 
-| Need | Read |
-|------|------|
-| Config fields, default `config.json`, template registry, domain profile options | [configuration.md](references/configuration.md) |
-| init, scan-organize, ingest, tag | [workflows-core.md](references/workflows-core.md) |
-| journal-report, direction-report, direction-review, stat-report, idea-survey, submission-recommend, revision-suggest, paper-read | [workflows-reports.md](references/workflows-reports.md) |
-| web-find, web-digest, web-import-clipper, academic source/data-layer rules | [workflows-web.md](references/workflows-web.md) |
-| status, lint, pipeline, maintenance utilities | [workflows-maintenance.md](references/workflows-maintenance.md) |
-| Script inventory and formal command surface | [scripts.md](references/scripts.md) |
-| Schema details, canonical page format, frontmatter fields | [schema.md](references/schema.md) |
-| User-facing Chinese output examples for workflows | [output-formats.md](references/output-formats.md) |
+```json
+{
+  "output_lang": "zh",
+  "templates": {
+    "regeneration_threshold": 0.2,
+    "registry": {}
+  },
+  "web_search": {
+    "default_top": 10,
+    "min_citations": 5,
+    "openalex_email": "",
+    "openalex_api_key": "",
+    "semantic_scholar_api_key": "",
+    "clipper_inbox": "workspace/web-inbox",
+    "output_root": "paper/web_search",
+    "arxiv_fulltext_default": true,
+    "arxiv_output_root": "paper/web_search",
+    "arxiv_fulltext_priority": ["html", "tex", "pdf", "api"],
+    "domain_profiles": {
+      "Battery": {"strict": true, "required_groups": [], "negative_keywords": [], "preferred_venues": []},
+      "TimeSeries": {"strict": false, "keywords": []}
+    },
+    "sources": ["openalex", "semanticscholar", "arxiv"]
+  }
+}
+```
 
-Do not duplicate long details from those references in the answer. Load the narrowest file that
-matches the workflow, then execute from that reference plus the core rules below.
+- `output_lang`: `"zh"` (Chinese, default) or `"en"` (English) — controls all user-facing output
+- `templates.registry`: tracks domain-specific template generation status
+- `templates.regeneration_threshold`: ratio of new papers that triggers template refresh
+- `web_search.default_top`: default number of online results to save
+- `web_search.min_citations`: OpenAlex citation threshold for default web-find
+- `web_search.openalex_api_key`: optional OpenAlex API key for normal quota-based access
+- `web_search.openalex_email`: optional OpenAlex contact email / mailto metadata
+- `web_search.semantic_scholar_api_key`: optional Semantic Scholar key
+- `web_search.clipper_inbox`: Obsidian Web Clipper Markdown import folder
+- `web_search.output_root`: research material layer for web search metadata and incomplete arXiv results
+- `web_search.arxiv_fulltext_default`: default to arXiv full-text capture for arXiv results
+- `web_search.arxiv_output_root`: root folder for web-search-only arXiv Markdown
+- `web_search.arxiv_fulltext_priority`: arXiv capture priority, default `html > tex > pdf > api`
+- `web_search.domain_profiles`: direction-level keywords, required keyword groups, negative keywords, and preferred venues used by web-find and web-digest domain filtering
+
+---
+
+## Output Language Rules
+
+All internal content (this SKILL.md, schemas, scripts, template structure) is in **English**.
+
+All user-facing output follows `output_lang` from `config.json`:
+- `zh` → Chinese reports, console messages, status summaries
+- `en` → English equivalents with identical structure
+
+File paths, directory names, variable names, and frontmatter keys remain in English regardless of `output_lang`.
+
+---
+
+## Report Citation Policy
+
+All report-generation workflows must maintain a citation registry while writing the report.
+
+- Add a numeric citation marker at every place where a paper is used as evidence in prose, tables, comparisons, trend claims, journal recommendations, or revision suggestions.
+- Use `[1]`, `[2]`, ... numbered by first appearance in the report. Reuse the same number for the same paper throughout the report.
+- The final `References` / `Reference List` section must include every paper cited in the report body and only papers cited in the report body.
+- Do not list papers that were retrieved or matched but not used as evidence. If a paper is included in the analysis, either cite it where it supports a claim or omit it from the final references.
+- Reference entries use: `[N] Title. Journal, Year. DOI: xxx. URL: xxx. Source: local path or [arxiv-web].`
+- If DOI is missing, omit the DOI field. If URL is missing, use `source_path`. If journal is missing, use `journal_abbr` or `arXiv`. If year is missing, use `published_date`; if unavailable, use `n.d.`
+
+Before finalizing a report, verify that citation numbers are continuous, every in-text citation has one reference entry, and every reference entry is cited at least once.
+
+Direction-review reference-count defaults:
+- Standard `direction-review`: target **40-80** references unless the user explicitly asks for a shorter note or the corpus is too sparse to support that range.
+- Deep `direction-review`: target **80-120** references when the user explicitly asks for a deep review, comprehensive review, full survey, or journal-style long review.
+- Do not inflate the reference list artificially. Every reference must still be cited in the body and used as evidence.
+
+## Full-Coverage Report Policy
+
+For `journal-report` and `direction-report`, the evidence pipeline is required before the report is considered complete. Prompt checkpoints guide the Agent, but `report_family.py --complete` is the authoritative completion gate.
+
+Bundle preparation initializes all required evidence files under `evidence_dir`. The workflow then fills them in stages; `verification.json` starts with checks set to `"pending"` and must only be changed to `"passed"` after count equality is verified.
+
+### Stage 1: Evidence Pipeline (REQUIRED BEFORE ANY REPORT WRITING)
+
+1. Create `screening.jsonl` under `evidence_dir` with one entry per record:
+   ```jsonl
+   {"ref_id": "R001", "decision": "confirmed_included", "reason": "..."}
+   {"ref_id": "R032", "decision": "uncertain_needs_review", "reason": "DOI pattern anomaly"}
+   {"ref_id": "R050", "decision": "metadata_only_duplicate", "reason": "same DOI as R047"}
+   ```
+
+2. Create `paper_notes.jsonl` with one brief evidence note per confirmed paper.
+
+3. Create `coverage_ledger.json` using the validator-compatible top-level schema:
+   ```json
+   {
+     "candidate_count": 51,
+     "confirmed_included": ["R001", "R002", "..."],
+     "metadata_only": ["R050"],
+     "excluded_wrong_scope": [],
+     "skipped_unreadable": [],
+     "uncertain_needs_review": ["R032"]
+   }
+   ```
+
+4. Output partition counts before report writing:
+   ```
+   Evidence pipeline complete:
+   - candidate_count: 51
+   - confirmed_included: 49
+   - metadata_only: 1
+   - excluded_wrong_scope: 0
+   - skipped_unreadable: 0
+   - uncertain_needs_review: 1
+   ```
+
+Leave `verification.json` checks as `"pending"` during Stage 1.
+
+### Stage 2: Report Writing
+
+After Stage 1 completes:
+
+5. Create `Paper Coverage Matrix` table listing every `confirmed_included` paper with citation marker
+6. Write report body citing each confirmed paper at least once
+7. Fill `synthesis_notes.md` with key findings from the confirmed evidence set
+
+### Stage 3: Pre-Finalize Verification (REQUIRED BEFORE OUTPUT)
+
+Verify the following equalities and OUTPUT the check result:
+
+```
+Verification check:
+- coverage_ledger.confirmed_count: 49
+- unique_cited_paper_count (count distinct [N] markers in body): 49
+- reference_entry_count (count Reference List entries): 49
+- All 49 confirmed papers appear in Coverage Matrix: YES
+
+Status: PASS / FAIL
+```
+
+After these checks pass, update `verification.json` with validator-compatible pass keys:
+
+```json
+{
+  "citation_check": "passed",
+  "coverage_check": "passed",
+  "evidence_consistency_check": "passed",
+  "candidate_count": 51,
+  "confirmed_included_count": 49,
+  "metadata_only_count": 1,
+  "uncertain_needs_review_count": 1,
+  "unique_cited_paper_count": 49,
+  "coverage_matrix_entry_count": 49,
+  "reference_entry_count": 49
+}
+```
+
+If any check fails, **STOP** and fix before finalizing.
+
+### Stage 4: Hard Completion Gate
+
+After the report Markdown exists and all evidence files are filled, run:
+
+```bash
+python scripts/report_family.py --mode journal --journal Energy --complete
+```
+
+or the equivalent `direction` command. The report is not complete until this command passes.
+
+### Allowed Exception
+
+User explicitly requests `--metadata-only` or "brief/selective report" → skip full coverage requirements, document boundary in `Coverage / Source Set`.
+
+---
 
 ## Workflow Routing
 
 Route user intent to the appropriate workflow:
 
-| User intent | Workflow |
-|-------------|----------|
-| initialize vault / 初始化文献库 | **init** |
-| scan papers / 扫描文献 / organize by journal / 整理期刊 | **scan-organize** |
-| ingest / 入库 / process paper / 处理论文 | **ingest** |
-| tag / 标签 / assign tags / 打标 | **tag** |
-| journal report / 期刊报告 | **journal-report** |
-| direction report / 方向报告 | **direction-report** |
-| review paper / literature review / 综述 / direction review | **direction-review** |
-| method stats / dataset stats / 方法统计 / 数据集统计 | **stat-report** |
-| idea survey / novelty survey / idea调研 | **idea-survey** |
-| read this paper / 单篇文献精读 / 阅读这篇文献 | **paper-read** |
-| web find / 联网检索 / 查找论文 / search papers | **web-find** |
-| daily digest / 今日 arxiv / 最新预印本 | **web-digest** |
-| import web clipper / 导入 web clipper | **web-import-clipper** |
-| submission recommendation / 投稿推荐 | **submission-recommend** |
-| revision suggestions / 修改建议 | **revision-suggest** |
-| vault status / 文献库状态 | **status** |
-| health check / 检查 / lint | **lint** |
-| full pipeline / 完整流程 | **pipeline** |
+| User Intent | Workflow | Standalone? |
+|-------------|----------|:-----------:|
+| "initialize vault" / "初始化文献库" | → **init** | ✅ |
+| "scan papers" / "扫描文献", "organize by journal" / "整理期刊" | → **scan-organize** | ✅ |
+| "ingest" / "入库", "process paper" / "处理论文" | → **ingest** | ✅ |
+| "tag" / "标签", "assign tags" / "打标" | → **tag** | ✅ |
+| "journal report for XX" / "XX期刊报告" | → **journal-report** | ✅ |
+| "direction report for XX" / "XX方向报告" | → **direction-report** | ✅ |
+| "review paper" / "literature review" / "综述" / "direction review" | → **direction-review** | ✅ |
+| "method stats" / "方法统计", "dataset stats" / "数据集统计" | → **stat-report** | ✅ |
+| "idea survey" / "novelty survey" / "idea调研" | → **idea-survey** | ✅ |
+| "read this paper" / "单篇文献精读" / "阅读这篇文献" | → **paper-read** | ✅ |
+| "web find" / "联网检索" / "查找论文" / "search papers" | → **web-find** | ✅ |
+| "daily digest" / "今日 arxiv" / "最新预印本" | → **web-digest** | ✅ |
+| "import web clipper" / "导入 web clipper" | → **web-import-clipper** | ✅ |
+| "submission recommendation" / "投稿推荐" | → **submission-recommend** | ✅ |
+| "revision suggestions" / "修改建议" | → **revision-suggest** | ✅ |
+| "vault status" / "文献库状态" | → **status** | ✅ |
+| "health check" / "检查" / "lint" | → **lint** | ✅ |
+| "full pipeline" / "完整流程" | → **pipeline** | ✅ |
 
-Use **direction-review** for survey-style review-paper drafting over a direction or focused topic.
-Use **direction-report** for shorter status reports, and **idea-survey** for novelty/similarity
-checks on a specific idea.
+**Important**: Every workflow can run independently. If preconditions are unmet, output a clear message (e.g., "No source manifest found. Run scan-organize first.") but do NOT auto-chain unless the user explicitly requests "full pipeline".
 
-Every workflow can run independently. If preconditions are unmet, report the missing prerequisite
-and stop unless the user explicitly requests the full pipeline or asks you to perform the missing
-step.
+Routing note:
+- Use **direction-review** when the user wants a review paper, literature review, or survey-style direction synthesis.
+- Use **idea-survey** when the user wants novelty or similarity analysis for a specific idea rather than a direction-level review.
 
-## Preconditions
+---
 
-| Workflow | Requires |
-|----------|----------|
-| init | none |
-| scan-organize | init |
-| ingest | init |
-| tag | ingest with at least one canonical page |
-| journal-report | canonical pages for the target journal |
-| direction-report | canonical pages plus a query or direction |
-| direction-review | canonical pages with readable `source_path` for the direction; optional focus |
-| stat-report | canonical pages with tags |
-| idea-survey | source papers; canonical/index preferred; web search optional |
-| paper-read | one source or canonical paper |
-| web-find | init plus query; CLI requires existing direction |
-| web-digest | init plus query; CLI requires existing direction |
-| web-import-clipper | init plus existing direction |
-| submission-recommend | candidate journal evidence; journal reports preferred |
-| revision-suggest | target journal evidence; journal report preferred |
-| status | init |
-| lint | init |
-| pipeline | none |
+## Precondition Matrix
 
-When a precondition is not met, output:
+| Workflow | Requires | Auto-generated by |
+|----------|----------|-------------------|
+| init | — | — |
+| scan-organize | init | — |
+| ingest | init | — |
+| tag | ingest (≥1 canonical page) | ingest |
+| journal-report | ingest (canonical pages for target journal; optional direction/query filters) | ingest |
+| direction-report | ingest (canonical pages) + query; optional direction filter | ingest |
+| direction-review | ingest (canonical pages with readable `source_path` for the direction; optional focus) | ingest; web supplementation happens inside the workflow |
+| stat-report | ingest + tag | ingest, tag |
+| idea-survey | init + source papers; canonical/index preferred; web search optional | ingest (preferred), web-find (optional) |
+| paper-read | init + one source or canonical paper | ingest (preferred) |
+| web-find | init + query; CLI requires existing direction, Agent may bootstrap a missing one after confirmation | init |
+| web-digest | init + query; CLI requires existing direction, Agent may bootstrap a missing one after confirmation | init |
+| web-import-clipper | init + existing direction | init |
+| submission-recommend | journal-report (for candidate journals) | journal-report |
+| revision-suggest | journal-report (for target journal) | journal-report |
+| status | init | — |
+| lint | init | — |
+| pipeline | — | — |
 
-- `zh`: `前置条件未满足：需要先运行 {workflow_name}。`
-- `en`: `Precondition not met: run {workflow_name} first.`
+When a workflow's precondition is not met, output:
+- `zh`: "前置条件未满足：需要先运行 {workflow_name}。"
+- `en`: "Precondition not met: run {workflow_name} first."
 
-## Output Language Rules
+---
 
-All internal skill material, schemas, scripts, template structure, paths, variable names, and
-frontmatter keys remain in English.
+## Template System
 
-All user-facing output follows `output_lang` in root `config.json`:
+### Generic Templates
 
-- `zh`: Chinese reports, console messages, and status summaries.
-- `en`: English equivalents with identical structure.
+Located in `templates/generic/`. Domain-agnostic, ship with the skill.
+Used as fallback when no domain-specific template exists.
 
-For concrete Chinese workflow output examples, read [output-formats.md](references/output-formats.md).
+Templates use `{{variable}}` placeholders as reusable report structure references.
+For `report_family.py`, the default formal CLI path for `journal-report` and `direction-report` now prepares a full-text run bundle in `workspace/cache/fulltext-report/`.
+Agent or LLM workflows must not read `records[*].source_path` directly for report writing. They must run `records[*].source_read_command` to create the Agent-safe temporary Markdown view, then read that temporary file. `source_path` remains the original Markdown path for traceability and human reading.
+Use `--metadata-only` only when a deterministic canonical-metadata report is explicitly desired.
 
-## Report Citation Policy
+Available generic templates:
+- `paper_canonical.md` — standard literature page
+- `journal_report.md` — journal survey report
+- `direction_report.md` — research direction report
+- `direction_review.md` — direction-level literature review scaffold
+- `idea_survey_report.md` — idea novelty survey
+- `paper_reading.md` — single-paper reading note
+- `stat_report.md` — method/dataset/experiment statistics
+- `submission_report.md` — submission recommendation
+- `revision_report.md` — revision suggestions
 
-All multi-paper report workflows must maintain a citation registry while writing.
+### Domain-Specific Templates
 
-- Add a numeric citation marker wherever a paper supports prose, tables, comparisons, trends,
-  recommendations, scoring, or revision advice.
-- Use `[1]`, `[2]`, and so on, numbered by first appearance. Reuse the same number for the same paper.
-- The final `References` / `Reference List` section must include every cited paper and only cited papers.
-- Do not list retrieved or matched papers that are not used as evidence.
-- Reference entries use: `[N] Title. Journal, Year. DOI: xxx. URL: xxx. Source: local path or [arxiv-web].`
-- If DOI is missing, omit DOI. If URL is missing, use `source_path`. If journal is missing, use
-  `journal_abbr` or `arXiv`. If year is missing, use `published_date`; if unavailable, use `n.d.`
+Located in `templates/domains/{domain_name}/`.
 
-Before finalizing a report, verify that citation numbers are continuous, every in-text citation has
-one reference entry, and every reference entry is cited at least once.
+Current codebase status:
+- `config.json` can track template registry metadata
+- `status_report.py` and `lint_vault.py` report registry state and staleness signals
+- the current formal CLI path does **not** auto-generate new domain templates
 
-Direction-review reference-count defaults:
+Practical rule:
+1. Prefer existing generic templates as the stable reference structure
+2. If a domain template already exists and the user explicitly wants it, treat it as a manual or Agent-selected reference
+3. Do not describe domain-template auto-generation as an implemented default behavior
 
-- Standard `direction-review`: target 40-80 references unless the user explicitly asks for a
-  shorter note or the corpus is too sparse to support that range.
-- Deep `direction-review`: target 80-120 references when the user explicitly asks for a deep,
-  comprehensive, full-survey, or journal-style long review.
-- Do not inflate the reference list artificially. Every reference must still be cited in the body
-  and used as evidence.
+---
 
-## Full-Coverage Report Policy
+## Workflow 1: init
 
-For `journal-report` and `direction-report`, if the report claims to analyze all selected, readable,
-confirmed, or relevant papers, maintain a `coverage_ledger` before writing.
+### Purpose
+Initialize the vault structure. Creates missing directories and seed files.
 
-- Confirm the evidence set first. Separate records into `confirmed_included`,
-  `excluded_wrong_scope`, `skipped_unreadable`, and `uncertain_needs_review`.
-- Cite every `confirmed_included` paper at least once in the report body. Prefer a `Paper Coverage
-  Matrix` table for this.
-- Do not satisfy coverage by adding uncited papers directly to the reference list.
-- Representative-only reports are allowed only when the user explicitly asks for a brief,
-  selective, or representative report; state that boundary in `Coverage / Source Set`.
+### Steps
 
-Before finalizing a full-coverage report, verify:
+1. Check if `E:\paper` has `config.json` — if not, create default config
+2. Create missing directories:
+   - `schema/`
+   - `library/papers/`, `library/reports/journal/`, `library/reports/direction/`, `library/reports/review/`, `library/reports/idea/`, `library/reports/paper/`, `library/reports/submission/`, `library/reports/vault/`
+   - `library/indexes/`
+   - `workspace/cache/`, `workspace/cache/fulltext-review/`, `workspace/manifests/`, `workspace/logs/`, `workspace/legacy/`
+   - `templates/generic/`, `templates/domains/`
+3. Create `schema/tag_taxonomy.json` if missing (empty initial structure)
+4. Create `schema/keyword_rules.json` if missing (empty rules array)
+5. Create `schema/paper_frontmatter.schema.md` if missing
+6. Skip creating generic templates if they already exist
+7. Update `paper-library.md` with skeleton if needed
 
-- `confirmed_included_count == coverage_ledger_count`
-- `coverage_ledger_count == unique_cited_paper_count`
-- `unique_cited_paper_count == reference_entry_count`
-- Every excluded, skipped, or uncertain record is reported separately and is not listed in references.
+### Output (zh)
+```
+文献库初始化完成！路径：E:\paper
 
-## Evidence Rules
+已创建目录：{list}
+已创建文件：{list}
 
-- Use canonical pages as index anchors; use `source_path` to read original Markdown under `paper/`
-  when report or reading conclusions require full-text evidence.
-- For `paper-read`, ground answers in the selected paper text. Label inference explicitly and write
-  "Not available in the provided paper text" when evidence is missing.
-- Do not use external literature unless the workflow or user request explicitly calls for web search
-  or comparison.
+接下来你可以：
+- "扫描文献" — 扫描 paper/ 目录
+- "整理期刊" — 按期刊缩写归类文件
+- "入库" — 处理论文并生成 canonical 页
+```
+
+---
+
+## Workflow 2: scan-organize
+
+> **Status**: Implemented (main flow) | duplicate detection: Implemented
+
+### Purpose
+Scan `paper/` for all Markdown files and optionally organize them into journal folders.
+
+### Sub-triggers
+- "scan papers" / "扫描文献" → steps 1–3 only (scan + plan)
+- "organize by journal" / "整理期刊" → steps 1–6 (scan + move + index)
+- "check duplicates" / "检查重复" → steps 1, 4 only
+
+### Steps
+
+1. Run: `python scripts/scan_sources.py`
+   - Output: `workspace/manifests/source_manifest.json`
+
+2. Run: `python scripts/organize_by_journal.py --all --dry-run`
+   - Output: `workspace/manifests/journal_move_plan.json`
+
+3. Display plan summary to user:
+   - Files to move (count by action: move/skip/warn/conflict)
+   - Journal distribution
+
+4. **(If "check duplicates")**: Run `python scripts/detect_duplicates.py --all`:
+   - Compare file SHA256 checksums (exact) and normalized title+year (probable)
+   - Generate `workspace/manifests/duplicate_report.json` and `.md`
+
+5. **(If "organize by journal")**: Ask user to confirm, then:
+   - Run: `python scripts/organize_by_journal.py --all --apply`
+
+6. Run: `python scripts/rebuild_indexes.py`
+   - Triggers domain profile update (see Template System)
+
+### Output (zh)
+```
+扫描完成：{N} 个文件
+
+按操作分类：
+- 移动：{move_count}
+- 跳过：{skip_count}
+- 冲突：{conflict_count}
+- 警告：{warn_count}
+
+计划已保存：workspace/manifests/journal_move_plan.json
+是否执行移动？(y/n)
+```
+
+---
+
+## Workflow 3: ingest
+
+### Purpose
+Process paper Markdown files: extract metadata, generate canonical pages, convert HTML tables.
+
+### Input
+- A specific file path, or "all new papers", or a journal/direction scope
+
+### Steps
+
+1. Identify target files:
+   - If path given → process that file
+   - If "all" → scan `paper/` for files without corresponding canonical pages in `library/papers/`
+   - If journal/direction given → filter accordingly
+
+2. For each target file:
+
+   a. **Read file** and parse frontmatter using the same logic as `scripts/common.py`
+
+   b. **Extract/complete metadata**:
+      - `title`: from frontmatter or filename
+      - `journal`, `journal_abbr`: from `resolve_journal()` logic
+      - `published_date`: parse from frontmatter `published`, `created`, or body text
+      - `doi`: extract from frontmatter `source` or body DOI patterns
+      - `url`: from frontmatter `source`
+
+   c. **Generate paper ID**: `{direction}-{year}-{journal_abbr}-{slug}`
+      - slug = first 5 significant words of title, lowercase, hyphenated
+
+   d. **Identify tag candidates** from title, abstract, keywords, highlights:
+      - Match against `schema/keyword_rules.json` patterns
+      - Agent or LLM review can optionally suggest extra tags during a manual path
+      - Rule-based tagging is the only built-in automatic write-back path
+
+   e. **Convert HTML tables** to Markdown:
+      - Run: `python scripts/html_table_to_md.py <file_path>` (if HTML tables found)
+      - Or an Agent can convert simple tables inline during a manual path
+
+   f. **Generate canonical page** to `library/papers/{direction}/{paper_id}.md`:
+      - Use template: `templates/generic/paper_canonical.md`
+      - Fill frontmatter fields, abstract, keywords
+      - Set `source_path` to link back to original source file
+      - Preserve `## User Notes` section if existing canonical page already exists
+
+3. **Domain profile update**: Count papers by domain tag, update `config.json` template registry
+
+### Batch Command
+```bash
+python scripts/ingest_batch.py --direction Battery --journal Energy --apply-tags --rebuild-indexes
+python scripts/ingest_batch.py --file paper/Battery/arxiv/example.md --apply-tags
+python scripts/ingest_batch.py --direction Battery --dry-run
+```
+
+### Output (zh)
+```
+入库完成：处理了 {N} 篇论文
+
+新增 canonical 页：
+- {paper_id_1}
+- {paper_id_2}
+
+标签候选（需确认）：
+- "transfer learning" → method [新标签]
+- "CALCE" → dataset [已有标签]
+
+确认添加新标签？(y/n)
+```
+
+---
+
+## Workflow 4: tag
+
+> **Status**: Implemented (read-only audit and write-back paths clarified)
+
+### Purpose
+Manage the tag system: view, edit, batch-assign, and analyze tags.
+
+### Sub-triggers
+- "view tags" / "查看标签" → display tag_taxonomy.json summary
+- "batch tag" / "批量打标" → run keyword rules on all canonical pages
+- "add tag" / "添加标签" → add a custom tag to taxonomy
+- "tag stats" / "标签统计" → show tag frequency distribution
+
+### Scripts
+
+| Script | Purpose | Command |
+|--------|---------|---------|
+| `scan_tags.py` | **Read-only audit**: scan tag coverage, rule hits | `python scripts/scan_tags.py --direction Battery --rules` |
+| `ingest_batch.py --apply-tags` | **Write-back entry**: batch tag canonical pages | `python scripts/ingest_batch.py --direction Battery --apply-tags` |
+
+**Note**: `scan_tags.py` is read-only and never modifies canonical pages. Tag write-back must use `ingest_batch.py --apply-tags`.
+
+### Steps (batch tag)
+
+1. Load `schema/tag_taxonomy.json` and `schema/keyword_rules.json`
+
+2. For each canonical page in `library/papers/`:
+   a. Read frontmatter tags
+   b. Apply keyword rules to title, abstract, keywords sections
+   c. Optional Agent review may suggest additional tags for manual confirmation
+   d. Merge rule: preserve user tags; add keyword-rule hits without overwriting existing user edits
+
+3. Apply tag updates through `python scripts/ingest_batch.py --direction Battery --apply-tags`
+
+4. Rebuild indexes when batch tagging changes canonical frontmatter
+
+### Commands
+```bash
+python scripts/ingest_batch.py --direction Battery --apply-tags --rebuild-indexes
+python scripts/scan_tags.py --direction Battery
+python scripts/scan_tags.py --direction Battery --rules --include-empty
+```
+
+### Output (zh)
+```
+批量打标完成：更新了 {N} 篇论文的标签
+
+标签分布：
+- task: SOH estimation (45), RUL prediction (38), SOC estimation (12), ...
+- method: LSTM (28), Transformer (22), GPR (15), PINN (12), ...
+- dataset: NASA (35), CALCE (30), Oxford (18), ...
+
+新增标签：{list}
+```
+
+---
+
+## Workflow 5: journal-report
+
+### Purpose
+Prepare a full-text literature survey workflow for a specific journal.
+
+### Formal CLI
+```bash
+python scripts/report_family.py --mode journal --journal RESS
+python scripts/report_family.py --mode journal --journal RESS --direction Battery --query "soh"
+python scripts/report_family.py --mode journal --journal RESS --metadata-only
+python scripts/report_family.py --mode journal --journal RESS --complete
+```
+
+### Steps
+
+1. Load canonical records from `library/indexes/canonical_pages.json` (or rebuild in memory if the index is missing)
+2. Filter by journal name or abbreviation
+3. If `--direction` is set, further restrict to that exact direction
+4. If `--query` is set, further restrict the journal subset using canonical query matching
+5. Partition selected records into:
+   - readable records with valid `source_path`
+   - skipped records with missing/unreadable source files
+6. Audit journal identity before writing:
+   - Do not rely only on the parent folder or canonical `journal_abbr`
+   - Confirm journal identity from DOI, URL, source-page journal title, or full-text journal heading
+   - For Elsevier journals, treat DOI prefix and ScienceDirect journal page evidence as stronger than folder name
+   - Partition records into:
+     - `confirmed_included`: journal identity confirmed
+     - `metadata_only`: duplicate or metadata-only records (use `metadata_only_duplicate` screening decision, map to `metadata_only` ledger partition)
+     - `excluded_wrong_scope`: wrong journal or out of scope
+     - `skipped_unreadable`: missing or unreadable source files
+     - `uncertain_needs_review`: ambiguous journal identity
+7. Save a single disposable run bundle:
+   - `workspace/cache/fulltext-report/{run_key}.json`
+8. Agent runs `records[*].source_read_command` for each readable record to create the Agent-safe temporary Markdown view, reads that temporary file, applies the journal audit, and writes the final report to:
+   - `library/reports/journal/{journal_key}-report-{date}.md`
+   - Before writing the final report, fill all required evidence files under `bundle.evidence_dir`: screening.jsonl, paper_notes.jsonl, coverage_ledger.json, synthesis_notes.md, verification.json
+9. Include a `Paper Coverage Matrix` in the final report:
+   - Every `confirmed_included` paper must appear in the matrix with a numeric citation marker
+   - Excluded, skipped, and uncertain records must be summarized separately without reference-list entries
+10. After the final report exists, run:
+   - `python scripts/report_family.py --mode journal ... --complete`
+11. Write a compact preparation/completion log entry to `workspace/logs/report_generation.md`
+
+### Notes
+- `--mode journal --journal RESS` means journal-only selection: select all canonical papers from that journal and do not apply extra filtering
+- `--direction` and `--query` only narrow the already-selected journal subset when explicitly provided
+- Missing source files are skipped silently; detailed reasons stay only in the run-bundle JSON
+- Final journal-report conclusions must come from full-text evidence, not from canonical metadata alone
+- Journal reports default to full coverage of `confirmed_included` records; write a representative-only report only when explicitly requested
+- `--complete` is the formal close-out step after the final Markdown report has been written
+- `--metadata-only` keeps the old deterministic canonical-metadata report path
+
+---
+
+## Workflow 6: direction-report
+
+### Purpose
+Prepare a full-text direction or topic status report from local canonical pages.
+
+### Formal CLI
+```bash
+python scripts/report_family.py --mode direction --query "soh"
+python scripts/report_family.py --mode direction --direction Battery --query "soh"
+python scripts/report_family.py --mode direction --direction Battery --query "soh" --metadata-only
+python scripts/report_family.py --mode direction --direction Battery --query "soh" --complete
+```
+
+### Steps
+
+1. Load canonical records from the whole vault
+2. If `--direction` is set, restrict to that exact direction
+3. Apply query matching using title, abstract, keywords, and tag fields
+4. Partition selected records into readable vs. skipped by `source_path`
+5. Save a single disposable run bundle:
+   - `workspace/cache/fulltext-report/{run_key}.json`
+6. Agent runs `records[*].source_read_command` for each readable record to create the Agent-safe temporary Markdown view, reads that temporary file, and writes the final report to:
+   - `library/reports/direction/{topic_slug}-report-{date}.md`
+   - Before writing the final report, fill all required evidence files under `bundle.evidence_dir`: screening.jsonl, paper_notes.jsonl, coverage_ledger.json, synthesis_notes.md, verification.json
+7. After the final report exists, run:
+   - `python scripts/report_family.py --mode direction ... --complete`
+8. Write a compact preparation/completion log entry to `workspace/logs/report_generation.md`
+
+### Notes
+- `--mode direction --query "soh"` allows cross-journal local screening from the whole vault
+- `--direction` only narrows the query scope when explicitly provided
+- Missing source files are skipped silently; detailed reasons stay only in the run-bundle JSON
+- Final direction-report conclusions must come from full-text evidence, not from canonical metadata alone
+- `--complete` is the formal close-out step after the final Markdown report has been written
+- `--metadata-only` keeps the deterministic canonical-metadata report path
+
+---
+
+## Workflow 7: stat-report
+
+### Purpose
+Generate deterministic statistics reports for one tag dimension.
+
+### Formal CLI
+```bash
+python scripts/report_family.py --mode stat --direction Battery --dimension method
+python scripts/report_family.py --mode stat --direction Battery --dimension dataset --cross-dimension method
+```
+
+### Steps
+
+1. Load canonical records for the direction
+2. Aggregate by the requested dimension:
+   - count papers per tag value
+   - compute yearly trend
+   - compute cross-tabulation with another tag dimension
+3. Generate deterministic Markdown tables
+4. Save to `library/reports/direction/{dimension}-stats-{date}.md`
+
+---
+
+## Workflow 8: idea-survey
+
+### Purpose
+Survey literature similarity to a user idea and assess novelty through LLM/full-text reading.
+
+### Current execution path
+This workflow is **LLM/Agent-driven**, not implemented as a `report_family.py` screening mode.
+
+### Steps
+
+1. Use canonical pages only as an index to locate source files through `source_path`
+2. Let the LLM/Agent read relevant source Markdown files under `paper/`
+3. During reading, extract problem, method, dataset, experiment setup, baselines, metrics, results, and limitations
+4. Let the LLM/Agent decide which papers are truly similar or dissimilar after reading full evidence
+5. If web supplementation is needed, run `web_search.py find` first and then let the LLM/Agent read the resulting source Markdown
+6. Generate the final report at `library/reports/idea/{idea_slug}-survey-{date}.md` only after the full-text review pass
+
+### Notes
+- Do not use keyword/tag similarity as the final idea candidate filter
+- Do not treat metadata-only matches as novelty evidence
+- Final novelty judgment must be grounded in source Markdown, not only canonical abstracts or tags
+
+---
+
+## Workflow 9: web-find
+
+> **Status**: Implemented (CLI fail-fast; Agent may bootstrap missing direction)
+
+### Purpose
+Search academic web sources and save results as Markdown files in the local vault.
+
+### Prerequisites
+- **CLI path**: `paper/{direction}/` directory must already exist before running `web_search.py`
+- **Agent path**: if direction is missing, the Agent may guide the user to choose one of two direction options and create it after confirmation
+
+### Data Layers
+- Formal full-text library: `paper/{direction}/{journal_abbr}/` for clipped journal papers and arXiv papers with extracted full text
+- Web-search research layer: `paper/web_search/{direction}/{source}/` for OpenAlex/Semantic Scholar metadata and arXiv non-full-text fallbacks
+- Knowledge layer: `library/` for canonical pages, indexes, and reports
+
+### Input
+- Required: `--direction {existing_direction}`
+- Required: query text, e.g. `web-find --direction Battery --query "battery RUL transformer" --top 10`
+- Optional: `--top N`, `--source mixed|openalex|semanticscholar|arxiv|venues`, `--fulltext`, `--no-fulltext`, `--arxiv-id`, `--no-domain-filter`, `--show-filtered`, `--dry-run`
+
+### Steps
+
+1. CLI behavior: validate that `paper/{direction}/` already exists. If missing, `web_search.py` fail-fast with guidance to create the direction before running `web-find`.
+
+2. Agent recovery branch for a missing direction:
+   - inspect the user query, configured directions, and `web_search.domain_profiles`
+   - offer **two direction options**:
+     - a best-match existing direction when one is plausible
+     - a suggested new direction name; if no existing direction fits, offer two suggested new names
+   - wait for user confirmation before making any filesystem or config changes
+   - after confirmation, append the chosen direction to `config.json -> directions`, create `paper/{direction}/` and `paper/web_search/{direction}/`, and seed a minimal `web_search.domain_profiles.{direction}` stub
+   - rerun the original `web-find` command with the confirmed direction
+
+3. Fetch results:
+   - Primary: OpenAlex (`search`, citation-filtered by `web_search.min_citations`; send `openalex_api_key` and optional `openalex_email` when configured)
+   - In mixed/openalex mode, query both high-citation classic papers and recent papers, then merge and deduplicate
+   - Secondary: Semantic Scholar, only when `semantic_scholar_api_key` is configured
+   - `--source venues`: keep only OpenAlex candidates whose venue matches `web_search.domain_profiles.{direction}.preferred_venues`
+   - Fallback: arXiv only when `--source arxiv`, or when `--source mixed` returns fewer than `--top`
+
+4. Domain-filter, rank, and deduplicate:
+   - Evaluate each candidate against `web_search.domain_profiles.{direction}`
+   - Strict profiles require all configured `required_groups` and reject strong negative keyword hits
+   - Save only accepted candidates unless `--no-domain-filter` is set
+   - arXiv ID is the primary identity for arXiv results
+   - DOI is the primary identity
+   - normalized title + year is the fallback identity
+   - never overwrite existing source Markdown files
+
+5. Save OpenAlex / Semantic Scholar results to:
+   - `paper/web_search/{direction}/openalex/{year}-{first_author}-{title_slug}.md`
+   - `paper/web_search/{direction}/semanticscholar/{year}-{first_author}-{title_slug}.md`
+   - API results include metadata, abstract, DOI/URL, source ID, and a note that formal full text should be supplied via Obsidian Web Clipper when needed
+
+6. Save arXiv results by full-text status:
+   - `full_text_extracted` → `paper/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
+   - `pdf_saved_only` / `abstract_only` / `failed` → `paper/web_search/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
+   - Try `html > tex > pdf > api` unless `--no-fulltext` is set
+
+7. Generate canonical pages and rebuild indexes only for formal source saves under `paper/{direction}/`
+
+8. Generate a web-find report:
+   - `library/reports/web/{date}-{direction}-find-report.md`
+   - Include local duplicates, arXiv full-text downloads, OA/SS metadata findings, skipped and failed records, and filtered-out candidates with reasons
+
+9. Write manifest and log:
+   - `workspace/manifests/arxiv_fulltext_results.json` for arXiv full text
+   - `workspace/manifests/web_search_results.json` for OA/SS metadata saves
+   - Include `filtered_out` so rejected candidates are auditable
+   - `workspace/logs/web_search.md`
+
+### Command
+```bash
+python scripts/web_search.py find --direction Battery --query "battery RUL transformer" --top 10
+python scripts/web_search.py find --direction Battery --source arxiv --arxiv-id 2502.18807v7 --fulltext
+```
+
+---
+
+## Workflow 10: web-digest
+
+> **Status**: Implemented (CLI fail-fast; Agent may bootstrap missing direction)
+
+### Purpose
+Fetch recent arXiv papers for a direction and save them as Markdown sources plus a digest report.
+
+### Input
+- Required: `--direction {existing_direction}`
+- Required: `--query "topic"`
+- Optional: `--top N`, `--no-domain-filter`, `--show-filtered`, `--dry-run`
+
+### Steps
+
+1. CLI behavior: validate that `paper/{direction}/` already exists. If missing, `web_search.py` fail-fast with guidance to create the direction before running `web-digest`.
+2. Agent recovery branch for a missing direction:
+   - reuse the same bootstrap flow as `web-find`
+   - analyze the query and existing direction/profile context
+   - offer two direction options and wait for user confirmation
+   - after confirmation, create the direction folders and config/profile stub, then rerun `web-digest`
+3. Build a profile-aware arXiv query from `web_search.domain_profiles.{direction}`
+4. Query arXiv by submitted date
+5. Apply the same domain filter and ranking path used by `web-find`
+6. Save arXiv full-text successes to `paper/{direction}/arxiv/`
+7. Use the same `html > tex > pdf > api` fallback as `web-find`
+8. Save PDF-only, abstract-only, and failed fallback records to `paper/web_search/{direction}/arxiv/`
+9. Generate canonical pages and rebuild indexes only when a full-text arXiv paper entered the formal library
+10. Generate digest report at `library/reports/web/{date}-{direction}-digest.md`, including filtered-out candidates
+11. Log the operation
+
+### Command
+```bash
+python scripts/web_search.py digest --direction Battery --query "battery health prognosis" --top 10
+```
+
+---
+
+## Workflow 11: web-import-clipper
+
+### Purpose
+Import Obsidian Web Clipper Markdown into the vault as full-text source Markdown.
+
+### Input
+- Required: `--direction {existing_direction}`
+- Optional: `--inbox path`, default from `web_search.clipper_inbox`
+- Optional: `--dry-run`
+
+### Steps
+
+1. Read `.md` files from `workspace/web-inbox/` or the provided inbox path
+2. Extract title, authors, year, journal, DOI, URL, and abstract from frontmatter/body
+3. Deduplicate by DOI or normalized title + year
+4. Save normalized Markdown to `paper/{direction}/{journal_abbr}/`
+5. Preserve clipped body content and add missing vault metadata
+6. Generate canonical pages, rebuild indexes, and write:
+   - `workspace/manifests/web_clipper_import.json`
+   - `workspace/logs/web_search.md`
+
+The importer archives successfully imported inbox files to `workspace/web-inbox/imported/`. Dry-run and skipped-existing files are not moved.
+
+### Command
+```bash
+python scripts/web_import_clipper.py --direction Battery
+```
+
+---
+
+## Workflow 12: submission-recommend
+
+### Purpose
+Recommend suitable journals for a user's paper based on local literature evidence.
+
+### Input
+Path to the user's paper (Markdown file)
+
+### Steps
+
+1. Read and analyze the user's paper:
+   - Extract: research topic, methods, datasets, key results, reference list
+
+2. Identify candidate journals from the vault (all journals with ≥ 5 papers)
+
+3. For each candidate journal:
+   a. Read the journal report if it exists; otherwise prompt user to generate one first
+   b. Score across 6 dimensions:
+
+   | Dimension | Weight | Description |
+   |-----------|--------|-------------|
+   | topic_fit | 0.25 | Does the paper's topic match the journal's recent hotspots? |
+   | method_fit | 0.20 | Does the method type align with the journal's preferences? |
+   | novelty_fit | 0.20 | Is the paper differentiated from the journal's recent work? |
+   | experiment_fit | 0.15 | Do datasets, metrics, and experiment scale meet journal norms? |
+   | citation_fit | 0.10 | Does the reference list cover the journal's key papers? |
+   | risk | -0.10 | Scope mismatch, insufficient novelty, experimental gaps |
+
+   c. Compute total score (0–100 scale)
+
+4. Rank top 5 journals by total score
+
+5. **Generate report** → `library/reports/submission/{paper_slug}-recommend-{date}.md`
+   - Use template: `templates/generic/submission_report.md`
+   - Apply the Report Citation Policy: cite journal reports and underlying papers where they support scoring evidence or recommendations, and list all cited evidence in `References`.
+
+### Output (zh)
+```
+投稿推荐报告
+
+论文：{title}
+
+推荐期刊 Top 5：
+1. {journal_1}（{score_1}/100）— {reason}
+2. {journal_2}（{score_2}/100）— {reason}
+3. {journal_3}（{score_3}/100）— {reason}
+4. {journal_4}（{score_4}/100）— {reason}
+5. {journal_5}（{score_5}/100）— {reason}
+
+报告已保存：library/reports/submission/{paper_slug}-recommend-{date}.md
+```
+
+---
+
+## Workflow 13: revision-suggest
+
+### Purpose
+Generate targeted revision suggestions for a paper aimed at a specific journal.
+
+### Input
+- Path to the user's paper (Markdown file)
+- Target journal name or abbreviation
+
+### Steps
+
+1. Read the user's paper
+
+2. Read the target journal's literature collection (canonical pages)
+
+3. Read the journal report if available
+
+4. Compare across 5 dimensions:
+
+   **a. Formatting (排版)**:
+   - Section structure vs. typical papers in the journal
+   - Figure/table style conventions
+   - Length norms
+
+   **b. Method Writing Style (方法写作风格)**:
+   - How methods are typically presented in this journal
+   - Level of mathematical formalism
+   - Pseudo-code vs. text description preferences
+
+   **c. Research Method Sufficiency (研究方法充足性)**:
+   - Number of baselines typically compared
+   - Ablation study expectations
+   - Statistical significance testing norms
+
+   **d. Introduction Alignment (引言适配)**:
+   - Research motivation framing typical of this journal
+   - Literature review scope and depth
+   - Problem statement style
+
+   **e. Reference Coverage (参考文献覆盖)**:
+   - Key papers from this journal that should be cited
+   - Reference count norms
+   - Self-citation patterns
+
+5. **Prioritize** suggestions by impact: critical → important → optional
+
+6. **Generate report** → `library/reports/submission/{paper_slug}-revision-for-{journal}-{date}.md`
+   - Use template: `templates/generic/revision_report.md`
+   - Apply the Report Citation Policy: cite target-journal papers where they support formatting, method, experiment, introduction, reference-coverage, or action-list suggestions, and list all cited evidence in `Evidence Basis`.
+
+### Output (zh)
+```
+面向 {journal} 的修改建议
+
+评估维度：
+- 排版：{score}/5 — {summary}
+- 方法写作：{score}/5 — {summary}
+- 研究方法：{score}/5 — {summary}
+- 引言适配：{score}/5 — {summary}
+- 参考文献：{score}/5 — {summary}
+
+关键修改建议（共 {N} 条）：
+1. [关键] {suggestion_1}
+2. [关键] {suggestion_2}
+3. [重要] {suggestion_3}
+...
+
+报告已保存：library/reports/submission/{paper_slug}-revision-for-{journal}-{date}.md
+```
+
+---
+
+## Workflow 14: status
+
+### Purpose
+Display vault status summary.
+
+### Formal CLI
+```bash
+python scripts/status_report.py
+python scripts/status_report.py --direction Battery
+```
+
+### Steps
+
+1. Load source records from `library/indexes/papers.json`
+2. Load canonical records from `library/indexes/canonical_pages.json`
+3. Summarize:
+   - source / canonical counts
+   - direction and journal distribution
+   - tag coverage across `tags_*`
+   - recent web/report activity from `workspace/logs/`
+   - template registry state from `config.json`
+4. Save:
+   - `library/reports/vault/status-{date}.md`
+   - `workspace/manifests/status_report.json`
+
+### Output (zh)
+```
+文献库状态
+
+论文总数：{total}
+按方向：
+- Battery: {count}
+- TimeSeries: {count}
+
+按期刊（前 5）：
+- Energy: {count}
+- JES: {count}
+- RESS: {count}
+- AppliedEnergy: {count}
+- JPS: {count}
+
+Canonical 页：{canonical_count} / {total}（{pct}% 已入库）
+标签覆盖率：{tagged_count} / {canonical_count}（{pct}%）
+
+领域模板：
+- battery: ✅ 已生成（{date}，{paper_count} 篇时生成）
+- timeseries: ❌ 未生成
+
+最近操作：
+{last_5_log_entries}
+```
+
+---
+
+## Workflow 15: lint
+
+### Purpose
+Health check for the vault.
+
+### Formal CLI
+```bash
+python scripts/lint_vault.py
+python scripts/lint_vault.py --direction Battery
+```
+
+### Checks
+
+1. **Orphan canonical pages**: canonical page exists but source file is missing
+2. **Missing canonical pages**: source file exists but no canonical page
+3. **Tag inconsistencies**: tags in canonical pages not in `tag_taxonomy.json`
+4. **Stale indexes**: index files older than the latest source/canonical files
+5. **Missing frontmatter**: canonical pages missing required fields
+6. **Broken source_path**: canonical points to a non-existent source file
+7. **Template staleness**: registry entries whose paper counts have outgrown their recorded baseline
+
+### Output files
+- `library/reports/vault/lint-{date}.md`
+- `workspace/manifests/lint_vault.json`
+
+### Output (zh)
+```
+文献库健康检查报告
+
+✅ 通过：
+- 索引更新状态
+- 标签一致性
+
+⚠️ 警告：
+- {N} 篇论文未入库（无 canonical 页）
+- {N} 个标签未在 taxonomy 中注册
+- 领域模板 battery 已过时（新增 {pct}% 论文）
+
+❌ 错误：
+- {N} 个 canonical 页找不到源文件
+
+建议操作：
+1. 运行 "入库" 处理未入库论文
+2. 运行 "标签" 更新标签体系
+3. 运行 "重建索引" 刷新索引
+```
+
+---
+
+## Workflow 16: pipeline
+
+### Purpose
+Execute the full preprocessing pipeline in sequence.
+
+### Steps
+
+Execute in order, stopping on errors:
+1. **init**
+2. **scan-organize** (scan only, no move unless user confirms)
+3. **ingest** (all unprocessed papers)
+4. **tag** (batch tag)
+5. **rebuild indexes** (via `python scripts/rebuild_indexes.py`)
+6. **status** (show final state)
+
+### Output (zh)
+```
+完整流程执行完成
+
+1. ✅ 初始化
+2. ✅ 扫描：{N} 个文件
+3. ✅ 入库：{N} 篇新增
+4. ✅ 打标：{N} 篇更新
+5. ✅ 索引重建
+6. 当前状态：{summary}
+```
+
+---
+
+## Workflow 17: paper-read
+
+### Purpose
+Read one paper deeply and generate a structured reading note for single-paper understanding.
+
+Answer these questions:
+- What problem does this paper solve?
+- Why is this problem important?
+- What method or model does it use?
+- Why can this method or model solve the problem?
+- What are the core conclusions?
+- What can be done next?
+
+### Input
+- Required: one paper path, title, DOI, canonical id, or source path
+- Preferred: canonical page under `library/papers/{direction}/`
+- Allowed: source Markdown under `paper/{direction}/...`
+- Optional: user research context, such as "focus on battery SOH" or "focus on method novelty"
+
+### Steps
+
+1. Locate the paper:
+   - If input is a path, read it directly.
+   - If input is a title, id, or DOI, search canonical pages first, then source files.
+   - If both source and canonical exist, prefer canonical metadata and inspect source/full text when needed.
+
+2. Read metadata:
+   - title, authors, journal, year, DOI, source path, tags.
+
+3. Read content:
+   - Abstract
+   - Introduction / motivation
+   - Method / model
+   - Experiments / datasets
+   - Results
+   - Limitations / discussion / conclusion
+   - Full text via `source_path` if canonical page provided
+
+4. Generate the reading note using `templates/generic/paper_reading.md`.
+
+5. Evidence discipline:
+   - Ground every answer in the paper text.
+   - If a point is inferred rather than explicitly stated, label it as inference.
+   - If information is missing, write "Not available in the provided paper text" rather than guessing.
+   - Do not use external literature unless the user explicitly asks for comparison.
+   - Because this workflow reads one paper, do not apply the multi-paper Report Citation Policy unless additional papers are used.
+
+6. Save output when the user asks for a file or when a durable note is useful:
+   - `library/reports/paper/{date}-{paper_id}-reading.md`
+
+### Output (zh)
+```
+单篇文献精读：{title}
+
+1. 这篇文章解决了什么问题？
+{answer}
+
+2. 这个问题为什么重要？
+{answer}
+
+3. 本文使用了什么方法或模型？
+{answer}
+
+4. 为什么这个方法或模型能解决这个问题？
+{answer}
+
+5. 核心结论是什么？
+{answer}
+
+6. 下一步可以怎么做？
+{answer}
+
+阅读笔记已保存：library/reports/paper/{date}-{paper_id}-reading.md
+```
+
+---
+
+## Workflow 18: direction-review
+
+### Purpose
+Prepare a review-writing bundle for one direction, combining local full-text evidence, related vault context, and default web supplementation.
+
+### Current execution path
+This workflow is **Agent-driven with a lightweight preparation script**, not a `report_family.py` mode.
+
+### Formal preparation command
+```bash
+python scripts/prepare_direction_review.py --direction Battery
+python scripts/prepare_direction_review.py --direction Battery --focus "battery SOH"
+python scripts/prepare_direction_review.py --direction Battery --focus "battery SOH" --top 6 --dry-run
+```
+
+### Input
+- Required: `--direction {existing_direction}`
+- Optional: `--focus "topic"`
+- Optional: `--top N` for approximate total web supplementation volume
+- Optional: `--dry-run`
+
+### Steps
+
+1. Validate that the direction exists and already has canonical pages with usable `source_path`. If canonical pages are missing, prompt the user to run `ingest` first.
+2. Load canonical pages for the direction.
+3. If `--focus` is set, further restrict the local set using title, abstract, keyword, and tag matching.
+4. Partition the selected local set into:
+   - readable records with valid `source_path`
+   - skipped records with missing/unreadable source files
+5. Derive 1-3 web queries from:
+   - the direction name
+   - the optional focus text
+   - top local task / method / application tags when available
+6. Run default web supplementation using the existing `web_search.py` logic:
+   - reuse current ranking, domain filtering, and arXiv full-text behavior
+   - allow both new formal full-text saves and web-layer metadata saves into the review bundle
+7. Gather related context paths from `library/reports/journal/`, `library/reports/direction/`, `library/reports/idea/`, and `library/reports/web/`.
+8. Build review hints from the local reading set:
+   - candidate method categories
+   - common datasets
+   - common metrics
+   - common applications
+   - suggested comparison tables
+9. Save the preparation outputs:
+   - `workspace/cache/fulltext-review/{run_key}.json`
+   - `workspace/manifests/direction_review_prepare.json`
+10. Agent reads every readable record in the bundle and writes the final review to:
+   - `library/reports/review/{direction-or-focus}-review-{date}.md`
+
+### Writing rules
+- This workflow borrows the **review-writing mode** from a review-oriented skill, but it must stay domain-agnostic.
+- Do not hardcode field-specific method taxonomies or section names from any pre-existing domain template.
+- Method categories, datasets, metrics, and application groupings must be inferred from the current direction corpus.
+- Every major section should include at least one comparison table.
+- Every major method category should end with a limitations paragraph.
+- Unless the user explicitly asks for a deep review, a standard `direction-review` should target **40-80** cited references.
+- When the user explicitly asks for a deep / comprehensive / full survey review, target **80-120** cited references.
+- Related reports in `library/reports/` are secondary context only; all substantive conclusions must still come from the paper text.
+
+### Notes
+- `direction-review` is not a replacement for `direction-report`.
+- `direction-report` remains the direction/topic status report workflow.
+- `direction-review` is the survey-style literature review workflow.
+- `--dry-run` still writes the preparation bundle and manifest, but it does not write the final review Markdown and may include preview-only web records that are not yet readable on disk.
+
+### Output (zh)
+```
+方向综述准备完成
+
+方向：{direction}
+聚焦主题：{focus_or_none}
+
+本地可读论文：{local_readable}
+本地跳过论文：{local_skipped}
+网络补充记录：{web_count}
+
+Bundle：workspace/cache/fulltext-review/{run_key}.json
+Manifest：workspace/manifests/direction_review_prepare.json
+最终综述目标：library/reports/review/{direction-or-focus}-review-{date}.md
+```
+
+---
+
+## Script Reference
+
+Scripts are in `scripts/` and use Python standard library only.
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `scan_sources.py` | Scan paper sources | `python scripts/scan_sources.py` |
+| `organize_by_journal.py` | Journal-based file organization | `python scripts/organize_by_journal.py --all --dry-run` |
+| `detect_duplicates.py` | Exact/probable duplicate detection | `python scripts/detect_duplicates.py --direction Battery` |
+| `rebuild_indexes.py` | Rebuild indexes | `python scripts/rebuild_indexes.py` |
+| `html_table_to_md.py` | Convert HTML tables | `python scripts/html_table_to_md.py <file>` |
+| `resolve_journal.py` | Inspect journal resolution for one source file | `python scripts/resolve_journal.py paper/Battery/Energy/example.md` |
+| `ingest_batch.py` | Batch-generate canonical pages and optionally apply keyword-rule tags | `python scripts/ingest_batch.py --direction Battery --apply-tags` |
+| `scan_tags.py` | Scan canonical tag coverage and keyword-rule hits | `python scripts/scan_tags.py --direction Battery --rules` |
+| `export_summaries.py` | Export titles, metadata, abstracts, and keywords for review | `python scripts/export_summaries.py --direction Battery --format json` |
+| `report_family.py` | Full-text journal/direction run-bundle preparation by default; `--complete` closes the run after the final report exists; deterministic reports with `--metadata-only`; stat reports unchanged | `python scripts/report_family.py --mode journal --journal RESS` |
+| `prepare_direction_review.py` | Prepare a direction-level literature review bundle with default web supplementation for Agent writing | `python scripts/prepare_direction_review.py --direction Battery --focus "battery SOH"` |
+| `status_report.py` | Vault status summary (Markdown + JSON) | `python scripts/status_report.py` |
+| `lint_vault.py` | Vault health check (Markdown + JSON) | `python scripts/lint_vault.py` |
+| `web_search.py` | Search OpenAlex/Semantic Scholar/arXiv and save Markdown papers | `python scripts/web_search.py find --direction Battery --query "topic"` |
+| `arxiv_fulltext.py` | Fetch arXiv HTML/TeX/PDF/API fallback full text | Imported by `web_search.py` |
+| `web_import_clipper.py` | Import Obsidian Web Clipper Markdown | `python scripts/web_import_clipper.py --direction Battery` |
+| `common.py` | Shared utilities | Imported by other scripts |
+
+All scripts use the vault root as project root (auto-detected from script location via `Path(__file__).resolve().parents[1]`).
+
+Historical draft scripts and one-off migration tools now live under `workspace/legacy/` and are not part of the formal workflow surface.
+
+---
+
+## Schema Reference
+
+### tag_taxonomy.json
+
+Defines tag dimensions and known tags:
+
+```json
+{
+  "dimensions": {
+    "task": { "label": "Task", "abbr_map": {} },
+    "method": { "label": "Method", "abbr_map": {} },
+    ...
+  },
+  "tags": {
+    "task": ["SOH estimation", ...],
+    "method": ["LSTM", ...],
+    ...
+  }
+}
+```
+
+### keyword_rules.json
+
+Maps text patterns to tags:
+
+```json
+{
+  "rules": [
+    { "pattern": "state of health|SOH", "tag": "SOH estimation", "dimension": "task" },
+    ...
+  ]
+}
+```
+
+### journal_aliases.json
+
+Maps journal full names to abbreviations. Already exists with 27+ entries.
+
+### paper_frontmatter.schema.md
+
+Documents required and optional frontmatter fields for canonical pages.
+
+---
+
+## Canonical Page Format
+
+Canonical pages in `library/papers/{direction}/{paper_id}.md` serve as **index anchors** linking to source files. They contain metadata, tags, abstract, and user notes — not full text.
+
+Full text reading and evidence retrieval should use `source_path` to access the original Markdown in `paper/`.
+
+```yaml
+---
+id: battery-2025-ress-bayesian-calibrated-pinn
+title: "Paper title"
+direction: Battery
+source_path: "paper/Battery/RESS/paper.md"
+source_checksum: sha256...
+
+journal: "Reliability Engineering & System Safety"
+journal_abbr: "RESS"
+published_date: "2025-12"
+published_year: 2025
+doi: "10.1016/..."
+url: "https://..."
+
+tags_task: []
+tags_method: []
+tags_dataset: []
+tags_domain: []
+tags_signal: []
+tags_application: []
+tags_metric: []
+tags_custom: []
+
+status: "unread"
+reading_priority: "medium"
+updated_at: timestamp
+---
+
+# Title
+
+## Source
+
+## Abstract
+
+## Keywords
+
+## User Notes
+<!-- User-maintained section. Scripts must never overwrite this. -->
+```
+
+---
 
 ## Safety Rules
 
-1. Never delete files in `paper/`; these are the user's original paper Markdown files.
-2. File moves require a dry run first, then user confirmation before applying.
-3. Preserve `## User Notes`; never overwrite content under this heading.
-4. Log file operations to `workspace/logs/`.
-5. Preserve tag priority: user tags > rule tags > manually confirmed extra suggestions.
-6. Do not remove user tags during automated or rule-assisted tagging.
-7. Do not move files across directions unless the user explicitly requests it.
-8. Do not overwrite existing target files; log conflicts instead.
+1. **Never delete** files in `paper/` — these are the user's original paper Markdown files
+2. **File moves** require `--dry-run` first, then user confirmation before `--apply`
+3. **Preserve `## User Notes`** — never overwrite content under this heading in any file
+4. **Log everything** — all file operations go to `workspace/logs/`
+5. **Tag priority** — user tags > rule tags > manually confirmed extra suggestions (never remove user tags)
+6. **No cross-direction moves** — files stay within their research direction unless user explicitly requests
+7. **No overwrites** — if target file exists during organize, log as conflict, do not overwrite

--- a/paper-wiki/scripts/report_family.py
+++ b/paper-wiki/scripts/report_family.py
@@ -29,6 +29,11 @@ from report_support import (
     year_counts,
     partition_records_by_source,
     load_canonical_records,
+    extract_numeric_citations,
+    extract_reference_section,
+    count_reference_entries,
+    extract_coverage_matrix_refs,
+    get_confirmed_ids,
 )
 from web_search import run_find
 
@@ -447,15 +452,27 @@ def complete_fulltext_run(config: dict[str, Any], args: argparse.Namespace, outp
     # Initialize evidence files if not exist
     initialize_evidence_files(cache_path)
 
-    # Validate evidence files
-    is_valid, errors = validate_evidence_files(cache_path)
-    if not is_valid:
-        print("Evidence validation failed:")
-        for error in errors:
-            print(f"  - {error}")
-        print(f"\nEvidence files location: {bundle.get('evidence_dir', 'unknown')}")
-        print("Fill required evidence files before completing the run.")
-        raise SystemExit("Completion blocked: evidence validation failed.")
+    # Single unified validation call with explicit report_path
+    is_valid, errors = validate_evidence_files(cache_path, report_path=output_path)
+
+    if errors:
+        print("VALIDATION FAILED")
+        print("")
+        print(f"- coverage_ledger.confirmed_included_count: {confirmed_count}")
+        print(f"- unique_cited_paper_count: {cited_count}")
+        print(f"- coverage_matrix_entry_count: {matrix_count}")
+        print(f"- reference_entry_count: {ref_count}")
+        print("")
+        for error in errors[:5]:
+            print(f"Mismatch: {error}")
+        print("")
+        print("Evidence files:")
+        for name, path in paths.items():
+            status = "EXISTS" if path.exists() else "MISSING"
+            print(f"- {name}: {status}")
+        print("")
+        print("Fix the evidence/report mismatch and re-run --complete.")
+        raise SystemExit("Completion blocked: validation failed.")
 
     return cache_path, bundle
 

--- a/paper-wiki/scripts/report_support.py
+++ b/paper-wiki/scripts/report_support.py
@@ -69,6 +69,245 @@ DEFAULT_REFERENCE_SECTION_HEADINGS = [
     "references and notes",
 ]
 
+SCREENING_TO_LEDGER_PARTITION = {
+    "confirmed_included": "confirmed_included",
+    "metadata_only_duplicate": "metadata_only",
+    "metadata_only": "metadata_only",
+    "excluded_wrong_scope": "excluded_wrong_scope",
+    "skipped_unreadable": "skipped_unreadable",
+    "uncertain_needs_review": "uncertain_needs_review",
+}
+
+
+def normalize_partition_entries(entries: Any, partition: str = "partition") -> list[str]:
+    """Normalize ledger partition entries to Ref ID strings.
+
+    Accepts both string entries and legacy object entries with ref_id field.
+    Returns list of normalized Ref ID strings.
+    """
+    if not isinstance(entries, list):
+        raise ValueError(f"{partition} must be a list, got {type(entries).__name__}")
+
+    normalized: list[str] = []
+    for idx, entry in enumerate(entries):
+        if isinstance(entry, str):
+            ref_id = entry.strip()
+            if not ref_id:
+                raise ValueError(f"{partition}[{idx}] is an empty Ref ID string")
+            normalized.append(ref_id)
+        elif isinstance(entry, dict):
+            ref_id = entry.get("ref_id")
+            if not isinstance(ref_id, str) or not ref_id.strip():
+                raise ValueError(
+                    f"{partition}[{idx}] legacy object missing non-empty string ref_id: {entry!r}"
+                )
+            normalized.append(ref_id.strip())
+        else:
+            raise ValueError(
+                f"{partition}[{idx}] expected string Ref ID or legacy object with ref_id, "
+                f"got {type(entry).__name__}: {entry!r}"
+            )
+    return normalized
+
+
+def build_coverage_ledger(screening_entries: list[dict[str, Any]]) -> tuple[list[str], dict[str, Any] | None]:
+    """Build coverage_ledger.json from screening.jsonl entries.
+
+    Returns tuple of (errors, ledger). Unknown decisions produce errors.
+    """
+    ledger = {
+        "candidate_count": len(screening_entries),
+        "confirmed_included": [],
+        "metadata_only": [],
+        "excluded_wrong_scope": [],
+        "skipped_unreadable": [],
+        "uncertain_needs_review": [],
+    }
+    errors: list[str] = []
+    for entry in screening_entries:
+        decision = entry.get("decision") or entry.get("status") or ""
+        ref_id = entry.get("ref_id")
+
+        if not decision:
+            errors.append(f"Empty decision for ref_id {ref_id or 'unknown'}")
+            continue
+
+        if decision not in SCREENING_TO_LEDGER_PARTITION:
+            errors.append(f"Unknown screening decision '{decision}' for ref_id {ref_id or 'unknown'}")
+            continue
+
+        partition = SCREENING_TO_LEDGER_PARTITION[decision]
+        if ref_id:
+            ledger[partition].append(ref_id)
+
+    return errors, ledger if not errors else None
+
+
+def get_confirmed_ids(ledger: dict[str, Any]) -> set[str]:
+    """Extract confirmed_included IDs from ledger (handles string or object arrays)."""
+    confirmed = ledger.get("confirmed_included", [])
+    return set(normalize_partition_entries(confirmed, "confirmed_included"))
+
+
+def extract_numeric_citations(report_body: str) -> set[int]:
+    """Extract unique numeric citation markers from report body (before References section)."""
+    grouped = re.findall(r"\[((?:\d+\s*,\s*)*\d+)\]", report_body)
+    markers: list[int] = []
+    for group in grouped:
+        markers.extend(int(part.strip()) for part in group.split(","))
+    return set(markers)
+
+
+def count_reference_entries(reference_section: str) -> int:
+    """Count reference entries starting with numeric markers like [1]."""
+    return len(re.findall(r"^\[\d+\]\s+", reference_section, re.MULTILINE))
+
+
+def extract_reference_section(markdown_text: str) -> str:
+    """Extract the References/Reference List section from report Markdown."""
+    headings = ["## References", "## Reference List", "# References", "# Reference List"]
+    for heading in headings:
+        if heading in markdown_text:
+            start = markdown_text.find(heading)
+            remaining = markdown_text[start + len(heading):]
+            next_section_match = re.search(r"\n#{1,3} ", remaining)
+            if next_section_match:
+                return remaining[:next_section_match.start()]
+            return remaining
+    return ""
+
+
+def extract_coverage_matrix_refs(
+    markdown_text: str,
+) -> tuple[set[str], dict[str, int], list[str]]:
+    """Extract Ref IDs and citation markers from Paper Coverage Matrix table.
+
+    Returns:
+        Tuple of (ref_ids, ref_to_citation, errors)
+    """
+    # Find matrix section, stopping at next heading
+    matrix_start = markdown_text.find("## Paper Coverage Matrix")
+    if matrix_start == -1:
+        return set(), {}, []
+
+    remaining = markdown_text[matrix_start:]
+    next_heading = re.search(r"\n## ", remaining[1:])
+    if next_heading:
+        matrix_section = remaining[: next_heading.start() + 1]
+    else:
+        matrix_section = remaining
+
+    ref_ids: set[str] = set()
+    ref_to_citation: dict[str, int] = {}
+    errors: list[str] = []
+    seen_refs: set[str] = set()
+
+    for line in matrix_section.split("\n"):
+        if not line.startswith("|") or line.startswith("|---"):
+            continue
+
+        cells = [c.strip() for c in line.split("|")]
+        if len(cells) < 4:  # Need at least: empty, Ref, Year, Paper
+            continue
+
+        ref_cell = cells[1]
+        paper_cell = cells[3] if len(cells) > 3 else ""
+
+        ref_match = re.match(r"(R\d+)", ref_cell)
+        if not ref_match:
+            continue
+
+        ref_id = ref_match.group(1)
+
+        # Check for duplicate Ref IDs
+        if ref_id in seen_refs:
+            errors.append(f"Duplicate Ref ID in Coverage Matrix: {ref_id}")
+            continue
+        seen_refs.add(ref_id)
+        ref_ids.add(ref_id)
+
+        # Extract citation marker from Paper column
+        cite_match = re.search(r"\[(\d+)\]", paper_cell)
+        if cite_match:
+            ref_to_citation[ref_id] = int(cite_match.group(1))
+        else:
+            errors.append(f"Missing citation marker for {ref_id} in Coverage Matrix Paper column")
+
+    return ref_ids, ref_to_citation, errors
+
+
+def validate_count_equality(
+    bundle_path: Path,
+    report_path: Path | None = None,
+) -> tuple[bool, list[str]]:
+    """Validate count equality between ledger, citations, coverage matrix, and references."""
+    import json
+    paths = evidence_file_paths(bundle_path)
+    errors: list[str] = []
+
+    ledger_path = paths["coverage_ledger"]
+    if not ledger_path.exists():
+        return False, ["coverage_ledger.json missing"]
+    ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+
+    try:
+        confirmed_ids = get_confirmed_ids(ledger)
+    except ValueError as e:
+        return False, [f"coverage_ledger.json confirmed_included error: {e}"]
+    confirmed_count = len(confirmed_ids)
+
+    if report_path is None:
+        bundle = load_json(bundle_path)
+        output_path_str = bundle.get("output_path", "")
+        if output_path_str:
+            report_path = ROOT / output_path_str
+
+    if report_path is None or not report_path.exists():
+        return False, ["Report Markdown file not found"]
+    report_text = report_path.read_text(encoding="utf-8")
+
+    body_before_refs = report_text
+    for heading in ["## References", "## Reference List"]:
+        if heading in report_text:
+            body_before_refs = report_text[:report_text.find(heading)]
+            break
+
+    cited_markers = extract_numeric_citations(body_before_refs)
+    cited_count = len(cited_markers)
+
+    ref_section = extract_reference_section(report_text)
+    ref_count = count_reference_entries(ref_section)
+
+    matrix_refs, matrix_citations, matrix_errors = extract_coverage_matrix_refs(report_text)
+    matrix_count = len(matrix_refs)
+
+    # Add matrix parsing errors
+    errors.extend(matrix_errors)
+
+    if confirmed_count != cited_count:
+        errors.append(f"confirmed_included_count ({confirmed_count}) != unique_cited_paper_count ({cited_count})")
+    if confirmed_count != ref_count:
+        errors.append(f"confirmed_included_count ({confirmed_count}) != reference_entry_count ({ref_count})")
+    if confirmed_count != matrix_count:
+        errors.append(f"confirmed_included_count ({confirmed_count}) != coverage_matrix_entry_count ({matrix_count})")
+
+    # Check for missing confirmed papers in matrix
+    missing_in_matrix = confirmed_ids - matrix_refs
+    if missing_in_matrix:
+        errors.append(f"Coverage Matrix missing confirmed refs: {sorted(missing_in_matrix)[:5]}")
+
+    # Check for extra refs in matrix not in confirmed
+    extra_in_matrix = matrix_refs - confirmed_ids
+    if extra_in_matrix:
+        errors.append(f"Coverage Matrix has extra refs not in confirmed: {sorted(extra_in_matrix)[:5]}")
+
+    # Check that all confirmed papers have citation markers
+    missing_citations = confirmed_ids - set(matrix_citations.keys())
+    if missing_citations:
+        errors.append(f"Coverage Matrix missing citation markers for: {sorted(missing_citations)[:5]}")
+
+    return len(errors) == 0, errors
+
 
 def source_read_command(bundle_path: Path, ref_id: str) -> str:
     """Generate the Agent-safe reading command for a bundle record."""
@@ -203,11 +442,14 @@ def initialize_evidence_files(bundle_path: Path) -> None:
         paths["verification"].write_text(json.dumps(default_verification, indent=2), encoding="utf-8")
 
 
-def validate_evidence_files(bundle_path: Path) -> tuple[bool, list[str]]:
-    """Validate that all required evidence files exist and are non-empty."""
+def validate_evidence_files(
+    bundle_path: Path,
+    report_path: Path | None = None,
+) -> tuple[bool, list[str]]:
+    """Validate evidence files with count equality checks."""
     import json
     paths = evidence_file_paths(bundle_path)
-    errors = []
+    errors: list[str] = []
 
     for name, path in paths.items():
         if not path.exists():
@@ -219,7 +461,75 @@ def validate_evidence_files(bundle_path: Path) -> tuple[bool, list[str]]:
             errors.append(f"Empty evidence file: {rel(path)}")
             continue
 
-        if name in ("screening", "paper_notes"):
+        if name == "screening":
+            entries = []
+            parse_errors = []
+            file_lines = content.split("\n")
+            for line_number, line in enumerate(file_lines, start=1):
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                try:
+                    entry = json.loads(stripped)
+                    entries.append(entry)
+                except json.JSONDecodeError as e:
+                    parse_errors.append(f"screening.jsonl malformed JSON at line {line_number}: {e}")
+
+            if parse_errors:
+                errors.extend(parse_errors)
+                continue
+
+            if not entries:
+                errors.append(f"{name}.jsonl has no data entries")
+                continue
+
+            ledger_errors, expected_ledger = build_coverage_ledger(entries)
+            errors.extend(ledger_errors)
+
+            ledger_path = paths["coverage_ledger"]
+            if ledger_path.exists() and expected_ledger:
+                try:
+                    actual_ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError as e:
+                    errors.append(f"coverage_ledger.json invalid JSON: {e}")
+                    continue
+
+                for partition in [
+                    "confirmed_included",
+                    "metadata_only",
+                    "excluded_wrong_scope",
+                    "skipped_unreadable",
+                    "uncertain_needs_review",
+                ]:
+                    try:
+                        expected_set = set(
+                            normalize_partition_entries(expected_ledger.get(partition, []), partition)
+                        )
+                    except ValueError as e:
+                        errors.append(f"generated coverage ledger {e}")
+                        continue
+
+                    try:
+                        actual_set = set(
+                            normalize_partition_entries(actual_ledger.get(partition, []), partition)
+                        )
+                    except ValueError:
+                        # The coverage_ledger branch reports malformed ledger entries with
+                        # file/partition/index context; avoid duplicating that error here.
+                        continue
+
+                    if expected_set != actual_set:
+                        missing = expected_set - actual_set
+                        extra = actual_set - expected_set
+                        if missing:
+                            errors.append(f"screening-to-ledger mismatch in {partition}: missing {sorted(missing)[:3]}")
+                        if extra:
+                            errors.append(f"screening-to-ledger mismatch in {partition}: extra {sorted(extra)[:3]}")
+
+                if expected_ledger.get("candidate_count", 0) != actual_ledger.get("candidate_count", 0):
+                    errors.append(f"screening-to-ledger mismatch: candidate_count screening ({expected_ledger.get('candidate_count', 0)}) != ledger ({actual_ledger.get('candidate_count', 0)})")
+
+        elif name == "paper_notes":
             lines = [l for l in content.split("\n") if l.strip() and not l.strip().startswith("#")]
             if not lines:
                 errors.append(f"{name}.jsonl has no data entries")
@@ -244,6 +554,25 @@ def validate_evidence_files(bundle_path: Path) -> tuple[bool, list[str]]:
                         errors.append(f"coverage_ledger.json missing {field}")
                     elif not isinstance(data[field], list):
                         errors.append(f"coverage_ledger.json {field} must be a list")
+                    else:
+                        try:
+                            normalize_partition_entries(data[field], field)
+                        except ValueError as e:
+                            errors.append(f"coverage_ledger.json {e}")
+
+                try:
+                    confirmed_ids = get_confirmed_ids(data)
+                except ValueError as e:
+                    errors.append(f"coverage_ledger.json confirmed_included error: {e}")
+                    confirmed_ids = set()
+
+                total_partitioned = sum(
+                    len(data.get(field, []))
+                    for field in required_lists
+                    if isinstance(data.get(field, []), list)
+                )
+                if total_partitioned != data.get("candidate_count", 0):
+                    errors.append(f"coverage_ledger.json partition sum ({total_partitioned}) != candidate_count ({data.get('candidate_count', 0)})")
             except json.JSONDecodeError as e:
                 errors.append(f"coverage_ledger.json invalid JSON: {e}")
 
@@ -256,10 +585,27 @@ def validate_evidence_files(bundle_path: Path) -> tuple[bool, list[str]]:
             try:
                 data = json.loads(content)
                 for check in ["citation_check", "coverage_check", "evidence_consistency_check"]:
-                    if data.get(check) != "passed":
-                        errors.append(f"verification.json {check} not passed")
+                    status = data.get(check)
+                    if status != "passed":
+                        errors.append(f"verification.json {check} not passed (status: {status})")
+
+                confirmed_count = data.get("confirmed_included_count", 0)
+                cited_count = data.get("unique_cited_paper_count", 0)
+                ref_count = data.get("reference_entry_count", 0)
+                matrix_count = data.get("coverage_matrix_entry_count", 0)
+
+                if confirmed_count != cited_count:
+                    errors.append(f"verification.json count mismatch: confirmed ({confirmed_count}) != cited ({cited_count})")
+                if confirmed_count != ref_count:
+                    errors.append(f"verification.json count mismatch: confirmed ({confirmed_count}) != refs ({ref_count})")
+                if confirmed_count != matrix_count:
+                    errors.append(f"verification.json count mismatch: confirmed ({confirmed_count}) != matrix ({matrix_count})")
             except json.JSONDecodeError as e:
                 errors.append(f"verification.json invalid JSON: {e}")
+
+    count_ok, count_errors = validate_count_equality(bundle_path, report_path=report_path)
+    if not count_ok:
+        errors.extend(count_errors)
 
     return len(errors) == 0, errors
 
@@ -282,21 +628,29 @@ def source_reading_policy(config: dict[str, Any], args: Any | None = None) -> di
         "batch_id_style": "ref_range",
         "batch_atomic_write": True,
         "instruction": (
-            "Prefer source_read_batches[*].source_read_batch_command to create Agent-safe Markdown files in batches. "
-            "Read the generated manifest and per-ref files from each batch output_dir. "
-            "Use records[*].source_read_quiet_command or records[*].source_read_command only for single-paper retry, debugging, or paper-read workflows. "
-            "Remote Markdown images are converted to ordinary Markdown links, preserving URLs without triggering multimodal image handling. "
-            "Read the full Markdown including References. "
-            "Before writing the final report, fill all required evidence files under evidence_dir. "
-            "Required: screening.jsonl, paper_notes.jsonl, coverage_ledger.json, synthesis_notes.md, verification.json."
+            "**SEQUENTIAL EVIDENCE PIPELINE**\n\n"
+            "Stage 1: Execute source_read_batches to create Agent-safe Markdown views.\n\n"
+            "Stage 2: For each read paper, append audit decisions to screening.jsonl and evidence notes to paper_notes.jsonl. "
+            "Example: {\"ref_id\": \"R001\", \"decision\": \"confirmed_included\", \"doi_prefix\": \"10.1016/j.energy\", \"summary\": \"...\"}\n\n"
+            "Stage 3: After all papers read, create validator-compatible coverage_ledger.json with candidate_count, confirmed_included, metadata_only, excluded_wrong_scope, skipped_unreadable, and uncertain_needs_review. "
+            "Screening decision metadata_only_duplicate maps into ledger partition metadata_only.\n\n"
+            "Checkpoint: Output partition counts before report writing.\n\n"
+            "Stage 4: After Stage 3 completes, write report Markdown and synthesis_notes.md.\n\n"
+            "Stage 5: Before finalizing, verify count equality and update verification.json with citation_check, coverage_check, and evidence_consistency_check set to passed.\n\n"
+            "Stage 6: Run report_family.py --complete. The report is not complete until this passes.\n\n"
+            "Required files: screening.jsonl, paper_notes.jsonl, coverage_ledger.json, synthesis_notes.md, verification.json"
             if include
-            else "Prefer source_read_batches[*].source_read_batch_command to create Agent-safe Markdown files in batches. "
-            "Read the generated manifest and per-ref files from each batch output_dir. "
-            "Use records[*].source_read_quiet_command or records[*].source_read_command only for single-paper retry, debugging, or paper-read workflows. "
-            "Remote Markdown images are converted to ordinary Markdown links, preserving URLs without triggering multimodal image handling. "
-            "Ignore References/Bibliography sections from source papers unless explicitly requested. "
-            "Before writing the final report, fill all required evidence files under evidence_dir. "
-            "Required: screening.jsonl, paper_notes.jsonl, coverage_ledger.json, synthesis_notes.md, verification.json."
+            else "**SEQUENTIAL EVIDENCE PIPELINE**\n\n"
+            "Stage 1: Execute source_read_batches to create Agent-safe Markdown views.\n\n"
+            "Stage 2: For each read paper, append audit decisions to screening.jsonl and evidence notes to paper_notes.jsonl. "
+            "Example: {\"ref_id\": \"R001\", \"decision\": \"confirmed_included\", \"doi_prefix\": \"10.1016/j.energy\", \"summary\": \"...\"}\n\n"
+            "Stage 3: After all papers read, create validator-compatible coverage_ledger.json with candidate_count, confirmed_included, metadata_only, excluded_wrong_scope, skipped_unreadable, and uncertain_needs_review. "
+            "Screening decision metadata_only_duplicate maps into ledger partition metadata_only.\n\n"
+            "Checkpoint: Output partition counts before report writing.\n\n"
+            "Stage 4: After Stage 3 completes, write report Markdown and synthesis_notes.md.\n\n"
+            "Stage 5: Before finalizing, verify count equality and update verification.json with citation_check, coverage_check, and evidence_consistency_check set to passed.\n\n"
+            "Stage 6: Run report_family.py --complete. The report is not complete until this passes.\n\n"
+            "Required files: screening.jsonl, paper_notes.jsonl, coverage_ledger.json, synthesis_notes.md, verification.json"
         ),
     }
 

--- a/paper-wiki/templates/generic/direction_report.md
+++ b/paper-wiki/templates/generic/direction_report.md
@@ -75,6 +75,14 @@
 
 ### Long-term Challenges
 
+## Paper Coverage Matrix
+
+| Ref | Year | Paper | Main Task | Method | Included Reason |
+|-----|------|-------|-----------|--------|-----------------|
+
+<!-- Every confirmed included paper must appear here with a numeric citation marker [N] in the Paper column -->
+<!-- This matrix ensures full-coverage accountability for the direction-report workflow -->
+
 ## References
 
 <!--


### PR DESCRIPTION
 Fixed four runtime crash issues in the evidence validation protocol
  enforcement system:

  1. NameError from undefined `line` variable scope in screening.jsonl parsing
     - Changed list comprehension to explicit for-loop with line_number tracking
     - Added enumerate(file_lines, start=1) for precise error location

  2. TypeError from unhashable dict entries in ledger partition comparison - Added normalize_partition_entries() to convert legacy object entries (with ref_id field) to string Ref IDs before set comparison

  3. Silent mapping of unknown screening decisions to catch-all partition
     - build_coverage_ledger() now returns (errors, ledger) tuple
     - Unknown decisions produce validation errors, not silent fallback

  4. ValueError propagation from malformed confirmed_included entries - Added try/except wrapper in validate_count_equality() - Added partition validation in validate_evidence_files() coverage_ledger branch

  Additional changes:
  - normalize_partition_entries() enhanced with:
    - partition name parameter for contextual error messages
    - index tracking for precise error location
    - ValueError for empty Ref ID strings
    - ValueError for non-list partition entries