### PR TITLE
MCP Integration for Web Search Workflows

### DIFF
--- a/paper-wiki/SKILL.md
+++ b/paper-wiki/SKILL.md
@@ -115,6 +115,7 @@ Route user intent to the appropriate workflow and reference file:
 - For reviewer-backed workflows (idea-evidence, idea-create, idea-discover, idea-claim-novelty-check): prefer Codex-compatible MCP reviewer, otherwise dual-agent, otherwise degraded single-agent. Label degraded mode.
 - For review/audit workflows (auto-review-loop, resubmit-audit, paper-review-loop): prefer Codex-compatible MCP reviewer. In Claude Code, explicitly call `codex`. Fallback to dual-agent then single-agent degraded.
 - **Conference Seed Mode**: When idea-create is triggered with an explicit conference paper file path, load `references/workflows/19-idea-evidence.md` and execute its `### Conference Seed Mode` section first. The routing table entry for idea-create includes this path; the activation gate is in `references/workflows/20-idea-create.md`.
+- **MCP-first web search**: For web-find and web-digest workflows, MCP tools (`paper-search-mcp`, `arxiv-mcp-server`) are preferred when available. Fallback to CLI (`web_search.py`) when MCP unavailable. At workflow completion, if CLI was used, output MCP installation suggestion. Do NOT auto-install MCP servers; follow official docs if user agrees.
 
 ---
 

--- a/paper-wiki/references/configuration.md
+++ b/paper-wiki/references/configuration.md
@@ -19,6 +19,37 @@
     "novelty_check_sources": ["canonical_pages", "source_markdown", "web_digest"],
     "live_web_search": false
   },
+  "mcp": {
+    "enabled": true,
+    "fallback_to_cli": true,
+    "fallback_on_empty": false,
+    "timeout_seconds": 30,
+    "paper_search": {
+      "enabled": true,
+      "broad_sources": ["openalex", "semantic", "arxiv"]
+    },
+    "arxiv": {
+      "enabled": true,
+      "content_priority": ["html", "tex", "pdf"],
+      "download_fulltext": {
+        "exact_id": true,
+        "source_arxiv": true,
+        "mixed": false,
+        "digest": false,
+        "max_fulltext_per_run": 5
+      }
+    }
+  },
+  "web_digest": {
+    "lookback_days": 7,
+    "sort_by": "submittedDate",
+    "sort_order": "descending",
+    "use_alerts": false
+  },
+  "web_find": {
+    "default_top": 10,
+    "venues": []
+  },
   "web_search": {
     "default_top": 10,
     "min_citations": 5,
@@ -33,6 +64,7 @@
     "domain_profiles": {
       "ExampleDirection": {
         "strict": true,
+        "arxiv_categories": ["cs.AI", "cs.LG", "stat.ML"],
         "required_groups": [
           {"name": "core_topic", "terms": ["keyword a", "keyword b"]},
           {"name": "method_family", "terms": ["method x", "method y"]}
@@ -40,7 +72,11 @@
         "negative_keywords": ["unrelated topic"],
         "preferred_venues": ["Example Journal", "Another Journal"]
       },
-      "AnotherDirection": {"strict": false, "keywords": ["keyword c", "keyword d"]}
+      "AnotherDirection": {
+        "strict": false,
+        "arxiv_categories": ["cs.CL", "cs.IR"],
+        "keywords": ["keyword c", "keyword d"]
+      }
     },
     "sources": ["openalex", "semanticscholar", "arxiv"]
   }
@@ -49,12 +85,63 @@
 
 ## 参数说明
 
+### 基础配置
+
 | 配置项 | 默认值 | 说明 |
 |--------|--------|------|
 | `output_lang` | `"zh"` | 输出语言：`"zh"` 中文，`"en"` 英文 |
 | `directions` | `[]` | `paper/` 下的研究方向文件夹名称列表 |
 | `templates.regeneration_threshold` | `0.2` | 触发模板更新的文献增长比例 |
 | `templates.registry` | `{}` | 记录领域模板状态和陈旧度信号 |
+
+### MCP 配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `mcp.enabled` | `true` | 是否启用 MCP 工具调用 |
+| `mcp.fallback_to_cli` | `true` | MCP 不可用时是否回退到 CLI |
+| `mcp.fallback_on_empty` | `false` | MCP 返回空结果时是否触发 fallback |
+| `mcp.timeout_seconds` | `30` | MCP 工具调用超时时间 |
+
+### MCP paper-search-mcp 配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `mcp.paper_search.enabled` | `true` | 是否启用 paper-search-mcp |
+| `mcp.paper_search.broad_sources` | `["openalex", "semantic", "arxiv"]` | 多源聚合搜索的默认源列表 |
+
+### MCP arxiv-mcp-server 配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `mcp.arxiv.enabled` | `true` | 是否启用 arxiv-mcp-server |
+| `mcp.arxiv.content_priority` | `["html", "tex", "pdf"]` | arXiv 全文获取格式优先级 |
+| `mcp.arxiv.download_fulltext.exact_id` | `true` | arXiv ID 精确搜索时是否下载全文 |
+| `mcp.arxiv.download_fulltext.source_arxiv` | `true` | arXiv 关键词搜索时是否下载全文 |
+| `mcp.arxiv.download_fulltext.mixed` | `false` | 多源混合搜索时是否下载 arXiv 全文 |
+| `mcp.arxiv.download_fulltext.digest` | `false` | digest 模式是否下载全文 |
+| `mcp.arxiv.download_fulltext.max_fulltext_per_run` | `5` | 单次运行最大全文下载数量 |
+
+### web_digest 配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `web_digest.lookback_days` | `7` | digest 回溯天数 |
+| `web_digest.sort_by` | `"submittedDate"` | 排序字段 |
+| `web_digest.sort_order` | `"descending"` | 排序方向 |
+| `web_digest.use_alerts` | `false` | 是否使用 alert 模式（增量获取） |
+
+### web_find 配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `web_find.default_top` | `10` | 默认返回结果数量 |
+| `web_find.venues` | `[]` | venue 过滤模式下的目标期刊列表 |
+
+### 研究工作流配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
 | `research_workflows.external_reviewer` | `"codex"` | review/audit 工作流默认优先尝试 Codex-compatible MCP reviewer；在 Claude Code 中 reviewer 名称为 `codex` |
 | `research_workflows.external_reviewer_model` | `""` | 外部 reviewer 的可选模型名；为空时使用运行时默认 |
 | `research_workflows.external_reviewer_effort` | `"xhigh"` | 外部 reviewer 的推理强度 |
@@ -62,6 +149,11 @@
 | `research_workflows.require_human_checkpoints` | `true` | review / revision checkpoint 是否默认需要用户确认 |
 | `research_workflows.novelty_check_sources` | `["canonical_pages","source_markdown","web_digest"]` | `idea-claim-novelty-check` 的默认证据层 |
 | `research_workflows.live_web_search` | `false` | 是否允许 `idea-claim-novelty-check` 额外触发一次实时 `web-find` |
+
+### 联网检索配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
 | `web_search.default_top` | `10` | 联网检索默认最大保存数量 |
 | `web_search.min_citations` | `5` | OpenAlex 默认最低引用量阈值过滤 |
 | `web_search.openalex_api_key` | `""` | 可选 OpenAlex API key，用于保障正常额度访问 |
@@ -72,7 +164,87 @@
 | `web_search.arxiv_fulltext_default` | `true` | arXiv 检索默认尝试保存全文 |
 | `web_search.arxiv_output_root` | `"paper/web_search"` | arXiv 联网检索兜底（非全文）存放目录 |
 | `web_search.arxiv_fulltext_priority` | `["html","tex","pdf","api"]` | arXiv 全文获取优先级 |
-| `web_search.domain_profiles` | `{}` | 方向级领域匹配规则。建议只保留通用字段结构，并按你自己的研究方向填写关键词组、负向词和偏好期刊。 |
+| `web_search.domain_profiles` | `{}` | 方向级领域匹配规则 |
+
+### domain_profiles 配置
+
+每个研究方向可定义独立的领域匹配规则：
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `domain_profiles.{direction}.strict` | `true` | 是否严格匹配所有 required_groups |
+| `domain_profiles.{direction}.arxiv_categories` | `[]` | arXiv 类别过滤（如 `["cs.AI", "cs.LG", "stat.ML"]`） |
+| `domain_profiles.{direction}.required_groups` | `[]` | 必需的关键词组列表 |
+| `domain_profiles.{direction}.negative_keywords` | `[]` | 负向关键词（命中则拒绝） |
+| `domain_profiles.{direction}.preferred_venues` | `[]` | 偏好期刊列表（venue 模式过滤） |
+| `domain_profiles.{direction}.keywords` | `[]` | 简单关键词列表（非严格模式） |
+
+## MCP 服务器安装建议
+
+当 MCP 服务器未安装时，web-find 和 web-digest 工作流将通过 CLI fallback 执行。工作流结束时将提示：
+
+> 建议安装 MCP 服务器以增强网络搜索功能：arxiv-mcp-server 和 paper-search-mcp。
+
+### arxiv-mcp-server 安装
+
+官方仓库：https://github.com/blazickjp/arxiv-mcp-server
+
+安装方式：
+```bash
+uv tool install arxiv-mcp-server
+```
+
+MCP 配置（添加到 Claude Code MCP 配置文件）：
+```json
+{
+  "mcpServers": {
+    "arxiv": {
+      "command": "uvx",
+      "args": ["arxiv-mcp-server"]
+    }
+  }
+}
+```
+
+**重要**：server alias 必须为 `"arxiv"` 才能匹配工作流文档中的工具名 `mcp__arxiv__*`。如果使用其他 alias（如 `"arxiv-mcp-server"`），工具名前缀会变为 `mcp__arxiv-mcp-server__*`，需要相应调整工作流。
+
+### paper-search-mcp 安装
+
+官方仓库：https://github.com/openags/paper-search-mcp
+
+安装方式：
+```bash
+uv tool install paper-search-mcp
+```
+
+MCP 配置：
+```json
+{
+  "mcpServers": {
+    "paper-search-mcp": {
+      "command": "uvx",
+      "args": ["paper-search-mcp"]
+    }
+  }
+}
+```
+
+**工具名映射**：
+- 统一多源搜索：`mcp__paper-search-mcp__search_papers`（推荐）
+- 单源搜索：`mcp__paper-search-mcp__search_openalex`, `mcp__paper-search-mcp__search_semantic`, `mcp__paper-search-mcp__search_arxiv` 等
+
+### MCP 服务器能力对比
+
+| 能力 | arxiv-mcp-server | paper-search-mcp |
+|:---|:---|:---|
+| arXiv 精确搜索 | ✓ primary | ✓ fallback |
+| arXiv 全文提取 (HTML/TeX/PDF) | ✓ | - |
+| 本地论文缓存管理 | ✓ | - |
+| 引用图谱 (Semantic Scholar) | ✓ | - |
+| 研究 alert (watch_topic) | ✓ | - |
+| 多源聚合搜索 (OA/SS/arXiv 等) | - | ✓ primary |
+| OA-first 下载链 | - | ✓ |
+| 去重聚合 | - | ✓ |
 
 ## 报告生成 (Report Generation)
 
@@ -101,9 +273,7 @@
 - `submission_report.md`
 - `revision_report.md`
 
-领域模板位于 `templates/domains/{domain_name}/`。当前代码可以在 `config.json` 中跟踪
-模板 registry 状态，`status_report.py` 和 `lint_vault.py` 会报告 registry 状态和陈旧度信号。
-正式 CLI 路径不会默认自动生成新的领域模板。
+领域模板位于 `templates/domains/{domain_name}/`。当前代码可以在 `config.json` 中跟踪模板 registry 状态，`status_report.py` 和 `lint_vault.py` 会报告 registry 状态和陈旧度信号。正式 CLI 路径不会默认自动生成新的领域模板。
 
 实践规则：
 1. 优先使用 `templates/generic/` 中的通用模板。

--- a/paper-wiki/references/workflows/09-web-find.md
+++ b/paper-wiki/references/workflows/09-web-find.md
@@ -5,79 +5,312 @@
 
 ## Workflow 9: web-find
 
-> **Status**: Implemented (CLI fail-fast; Agent may bootstrap missing direction)
+> **Status**: Implemented (MCP-first with CLI fallback)
 
 ### Purpose
+
 Search academic web sources and save results as Markdown files in the local vault.
 
 ### Prerequisites
+
 - **CLI path**: `paper/{direction}/` directory must already exist before running `web_search.py`
 - **Agent path**: if direction is missing, the Agent may guide the user to choose one of two direction options and create it after confirmation
+- **MCP path**: MCP tools are preferred when available; fallback to CLI when MCP unavailable
 
 ### Data Layers
+
 - Formal full-text library: `paper/{direction}/{journal_abbr}/` for clipped journal papers and arXiv papers with extracted full text
 - Web-search research layer: `paper/web_search/{direction}/{source}/` for OpenAlex/Semantic Scholar metadata and arXiv non-full-text fallbacks
 - Knowledge layer: `library/` for canonical pages, indexes, and reports
 
 ### Input
+
 - Required: `--direction {existing_direction}`
 - Required: query text, e.g. `web-find --direction Battery --query "battery RUL transformer" --top 10`
 - Optional: `--top N`, `--source mixed|openalex|semanticscholar|arxiv|venues`, `--fulltext`, `--no-fulltext`, `--arxiv-id`, `--no-domain-filter`, `--show-filtered`, `--dry-run`
 
+### MCP Integration
+
+This workflow uses a **MCP-first** strategy with CLI fallback:
+
+| Priority | Layer | Provider | Use Case |
+|:---:|:---|:---|:---|
+| 1 | Discovery | `paper-search-mcp` | Broad multi-source search (OpenAlex, Semantic Scholar, arXiv) |
+| 2 | arXiv Deep | `arxiv-mcp-server` | arXiv precise search, full-text extraction, citation graph |
+| 3 | Fallback | `web_search.py` CLI | Direct HTTP API when MCP unavailable |
+
+**MCP Tool Reference**:
+
+| MCP Server | Tool Name | Purpose |
+|:---|:---|:---|
+| `paper-search-mcp` | `mcp__paper-search-mcp__search_papers` | Unified multi-source search with deduplication |
+| `paper-search-mcp` | `mcp__paper-search-mcp__search_openalex` | OpenAlex single-source search |
+| `paper-search-mcp` | `mcp__paper-search-mcp__search_semantic` | Semantic Scholar single-source search |
+| `paper-search-mcp` | `mcp__paper-search-mcp__download_with_fallback` | OA-first download chain for non-arXiv papers |
+| `arxiv-mcp-server` | `mcp__arxiv__search_papers` | arXiv search with category/date filters |
+| `arxiv-mcp-server` | `mcp__arxiv__get_abstract` | Fast arXiv metadata by ID |
+| `arxiv-mcp-server` | `mcp__arxiv__download_paper` | Download arXiv full text (HTML/TeX/PDF) |
+| `arxiv-mcp-server` | `mcp__arxiv__read_paper` | Read downloaded arXiv paper content |
+
 ### Steps
 
-1. CLI behavior: validate that `paper/{direction}/` already exists. If missing, `web_search.py` fail-fast with guidance to create the direction before running `web-find`.
+#### Step 1: Parse inputs and check MCP availability
 
-2. Agent recovery branch for a missing direction:
-   - inspect the user query, configured directions, and `web_search.domain_profiles`
-   - offer **two direction options**:
-     - a best-match existing direction when one is plausible
-     - a suggested new direction name; if no existing direction fits, offer two suggested new names
-   - wait for user confirmation before making any filesystem or config changes
-   - after confirmation, append the chosen direction to `config.json -> directions`, create `paper/{direction}/` and `paper/web_search/{direction}/`, and seed a minimal `web_search.domain_profiles.{direction}` stub
-   - rerun the original `web-find` command with the confirmed direction
+1. Parse input arguments: `--direction`, `--query`, `--source`, `--top`, `--arxiv-id`
+2. Load `config.json` and check `mcp.enabled` setting
+3. Check MCP server availability:
+   - List available MCP tools via `ListMcpResourcesTool` or runtime check
+   - Record which MCP servers are connected: `paper-search-mcp`, `arxiv-mcp-server`
+4. If both MCP servers unavailable and `mcp.fallback_to_cli=true`, proceed to CLI fallback path
+5. If MCP unavailable and `mcp.fallback_to_cli=false`, report error and suggest MCP installation
 
-3. Fetch results:
-   - Primary: OpenAlex (`search`, citation-filtered by `web_search.min_citations`; send `openalex_api_key` and optional `openalex_email` when configured)
-   - In mixed/openalex mode, query both high-citation classic papers and recent papers, then merge and deduplicate
-   - Secondary: Semantic Scholar, only when `semantic_scholar_api_key` is configured
-   - `--source venues`: keep only OpenAlex candidates whose venue matches `web_search.domain_profiles.{direction}.preferred_venues`
-   - Fallback: arXiv only when `--source arxiv`, or when `--source mixed` returns fewer than `--top`
+#### Step 2: Route by intent
 
-4. Domain-filter, rank, and deduplicate:
-   - Evaluate each candidate against `web_search.domain_profiles.{direction}`
-   - Strict profiles require all configured `required_groups` and reject strong negative keyword hits
-   - Save only accepted candidates unless `--no-domain-filter` is set
-   - arXiv ID is the primary identity for arXiv results
-   - DOI is the primary identity
-   - normalized title + year is the fallback identity
-   - never overwrite existing source Markdown files
+Route the request based on input parameters:
 
-5. Save OpenAlex / Semantic Scholar results to:
-   - `paper/web_search/{direction}/openalex/{year}-{first_author}-{title_slug}.md`
-   - `paper/web_search/{direction}/semanticscholar/{year}-{first_author}-{title_slug}.md`
-   - API results include metadata, abstract, DOI/URL, source ID, and a note that formal full text should be supplied via Obsidian Web Clipper when needed
+| Input Condition | Route | Primary MCP |
+|:---|:---|:---|
+| `--arxiv-id` present | arXiv exact route | `arxiv-mcp-server` |
+| `--source=arxiv` | arXiv keyword route | `arxiv-mcp-server` |
+| `--source=mixed` | Broad discovery route | `paper-search-mcp` |
+| `--source=openalex` | Single-source route | `paper-search-mcp` |
+| `--source=semantic` | Single-source route | `paper-search-mcp` |
+| `--source=semanticscholar` | Single-source route (alias) | `paper-search-mcp` |
+| `--source=venues` | Venue-filtered route | `paper-search-mcp` |
+| No `--source` specified | Default: `mixed` route | `paper-search-mcp` |
 
-6. Save arXiv results by full-text status:
-   - `full_text_extracted` → `paper/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
-   - `pdf_saved_only` / `abstract_only` / `failed` → `paper/web_search/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
-   - Try `html > tex > pdf > api` unless `--no-fulltext` is set
+#### Step 3: Broad discovery route (`--source=mixed`)
 
-7. Generate canonical pages and rebuild indexes only for formal source saves under `paper/{direction}/`
+**Primary**: `mcp__paper-search-mcp__search_papers`
 
-8. Generate a web-find report:
-   - `library/reports/web/{date}-{direction}-find-report.md`
-   - Include local duplicates, arXiv full-text downloads, OA/SS metadata findings, skipped and failed records, and filtered-out candidates with reasons
+Call parameters:
+```json
+{
+  "query": "<user_query>",
+  "max_results_per_source": 5,
+  "sources": "openalex,semantic,arxiv"
+}
+```
 
-9. Write manifest and log:
-   - `workspace/manifests/arxiv_fulltext_results.json` for arXiv full text
-   - `workspace/manifests/web_search_results.json` for OA/SS metadata saves
-   - Include `filtered_out` so rejected candidates are auditable
-   - `workspace/logs/web_search.md`
+Response structure:
+```json
+{
+  "query": "...",
+  "sources_used": ["openalex", "semantic", "arxiv"],
+  "source_results": { "openalex": 5, "semantic": 3, "arxiv": 4 },
+  "papers": [...],
+  "total": 12,
+  "errors": {}
+}
+```
 
-### Command
+Process results:
+1. Save OpenAlex metadata to `paper/web_search/{direction}/openalex/`
+2. Save Semantic Scholar metadata to `paper/web_search/{direction}/semanticscholar/`
+3. Save arXiv metadata to `paper/web_search/{direction}/arxiv/`
+4. For arXiv hits, evaluate fulltext decision:
+   - If `config.mcp.arxiv.download_fulltext.mixed=true`, download full text for top N papers
+   - Cap downloads by `config.mcp.arxiv.download_fulltext.max_fulltext_per_run`
+
+**Fallback**: If `paper-search-mcp` unavailable or returns error:
+- Try `arxiv-mcp-server.search_papers` for arXiv portion
+- Then fall back to CLI: `python scripts/web_search.py find --source mixed ...`
+
+#### Step 4: Single-source route
+
+**OpenAlex** (`--source=openalex`):
+```json
+{
+  "tool": "mcp__paper-search-mcp__search_openalex",
+  "params": {
+    "query": "<user_query>",
+    "max_results": <top>
+  }
+}
+```
+
+**Semantic Scholar** (`--source=semanticscholar`):
+```json
+{
+  "tool": "mcp__paper-search-mcp__search_semantic",
+  "params": {
+    "query": "<user_query>",
+    "max_results": <top>
+  }
+}
+```
+
+**Venue-filtered** (`--source=venues`):
+- Use OpenAlex search with venue filter from `config.web_find.venues`
+- Filter results to match `config.domain_profiles.{direction}.preferred_venues`
+
+Save results to respective `paper/web_search/{direction}/{source}/` directories.
+
+#### Step 5: arXiv keyword route (`--source=arxiv`)
+
+**Primary**: `mcp__arxiv__search_papers`
+
+Call parameters:
+```json
+{
+  "query": "<user_query>",
+  "max_results": <top>,
+  "sort_by": "relevance",
+  "categories": ["<from config.domain_profiles.{direction}.arxiv_categories>"]
+}
+```
+
+Categories are sourced from:
+- `config.domain_profiles.{direction}.arxiv_categories` (if defined)
+- Common defaults: `["cs.AI", "cs.LG", "cs.CL", "cs.CV", "stat.ML"]`
+
+Process each result:
+1. Save metadata to `paper/web_search/{direction}/arxiv/`
+2. Evaluate fulltext decision:
+   - If `config.mcp.arxiv.download_fulltext.source_arxiv=true`, attempt full text download
+   - Use format priority from `config.mcp.arxiv.content_priority`: `["html", "tex", "pdf"]`
+
+#### Step 6: arXiv exact route (`--arxiv-id`)
+
+**Step 6A**: Get metadata via `mcp__arxiv__get_abstract`
+```json
+{
+  "arxiv_id": "<user_provided_id>"
+}
+```
+
+**Step 6B**: Download full text via `mcp__arxiv__download_paper`
+```json
+{
+  "paper_id": "<arxiv_id>"
+}
+```
+
+The download tool automatically:
+- Tries HTML first (best for modern papers)
+- Falls back to TeX source extraction
+- Falls back to PDF download
+
+**Step 6C**: If full text needed, read via `mcp__arxiv__read_paper`
+```json
+{
+  "paper_id": "<arxiv_id>"
+}
+```
+
+Save paths:
+- Full text extracted → `paper/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
+- Metadata only → `paper/web_search/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
+
+#### Step 7: Fulltext decision logic
+
+Evaluate whether to download full text for arXiv results based on `config.mcp.arxiv.download_fulltext`:
+
+| Condition | Download? | Config Key | Default |
+|:---|:---:|:---|:---:|
+| `--arxiv-id` exact route | Config-controlled | `exact_id` | true |
+| `--source=arxiv` keyword | Config-controlled, capped | `source_arxiv` | true |
+| `--source=mixed` broad | Config-controlled | `mixed` | false |
+| `--fulltext` flag override | Yes | Overrides config | - |
+| `--no-fulltext` flag | No | Overrides config | - |
+
+Download cap: `config.mcp.arxiv.download_fulltext.max_fulltext_per_run` (default: 5)
+
+Content format priority: `config.mcp.arxiv.content_priority` (default: `["html", "tex", "pdf"]`)
+
+#### Step 8: Domain filter and deduplicate
+
+Apply domain filtering to all results:
+1. Load `config.domain_profiles.{direction}`
+2. Evaluate each candidate against profile:
+   - `strict` mode: require all `required_groups` keyword groups
+   - Reject papers with strong `negative_keywords` hits
+3. Filter out non-matching papers unless `--no-domain-filter` is set
+
+Deduplicate by identity:
+1. Primary identity: DOI (`doi:<lowercase_doi>`)
+2. arXiv identity: arXiv ID (`arxiv:<lowercase_id>`)
+3. Fallback identity: normalized title + year + first author
+
+Never overwrite existing source Markdown files.
+
+#### Step 9: Normalize and write results
+
+For each saved paper, add MCP provenance to frontmatter:
+```yaml
+---
+# ... existing fields ...
+mcp_provider: "paper-search-mcp" | "arxiv-mcp-server"
+mcp_tool: "search_papers" | "download_paper" | "get_abstract"
+retrieved_at: <ISO timestamp>
+retrieval_path: "mcp" | "cli_fallback"
+---
+```
+
+Generate canonical pages only for formal source saves under `paper/{direction}/`:
+- Call `generate_canonical` for each full-text arXiv paper
+- Rebuild indexes via `rebuild_indexes.py`
+
+#### Step 10: Generate report and manifest
+
+Generate web-find report at:
+- `library/reports/web/{date}-{direction}-find-report.md`
+
+Report sections:
+1. Summary: total found, per-source counts, MCP vs CLI usage
+2. New Findings - OpenAlex/Semantic Scholar: table with title, authors, year, DOI, URL
+3. New Findings - arXiv Full Text: table with title, authors, year, arXiv link, fulltext status
+4. Filtered-out candidates: list with rejection reasons
+5. MCP status: which servers used, any fallback events
+6. Installation suggestion (if MCP unavailable)
+
+Write manifests:
+- `workspace/manifests/arxiv_fulltext_results.json` for arXiv full text
+- `workspace/manifests/web_search_results.json` for OA/SS metadata
+
+Log operation to `workspace/logs/web_search.md`
+
+#### Step 11: CLI fallback path
+
+**Fallback rule**: CLI fallback is allowed only when `config.mcp.fallback_to_cli=true` AND one of the fallback triggers occurs.
+
+**Fallback triggers**:
+- Both MCP servers (`paper-search-mcp`, `arxiv-mcp-server`) unavailable
+- MCP tool call timeout or error
+- `config.mcp.enabled=false`
+
+**No fallback**:
+- Valid empty result (no papers matching query) - unless `config.mcp.fallback_on_empty=true`
+- `config.mcp.fallback_to_cli=false` - report error instead of using CLI
+
+If fallback triggered, execute CLI:
+
+```bash
+python scripts/web_search.py find --direction {direction} --query "{query}" --top {top} --source {source}
+```
+
+CLI behavior (unchanged from legacy):
+1. Validate `paper/{direction}/` exists (fail-fast if missing)
+2. Direct HTTP requests to OpenAlex, Semantic Scholar, arXiv APIs
+3. Apply domain filter and save to same directory structure
+4. Generate same report format
+
+At workflow completion, if CLI was used due to MCP unavailable:
+- Output suggestion: "建议安装 MCP 服务器以增强网络搜索功能：arxiv-mcp-server 和 paper-search-mcp。详见 config.json 中的 mcp 配置说明。"
+- Do NOT auto-install MCP servers
+- If user agrees to install, follow official docs from each MCP repository
+
+### Command Reference
+
+**MCP path (Agent)**:
+```
+# Intent routing handled by Agent per above steps
+web-find --direction Battery --query "battery RUL transformer" --top 10
+web-find --direction Battery --source arxiv --arxiv-id 2502.18807v7 --fulltext
+```
+
+**CLI path**:
 ```bash
 python scripts/web_search.py find --direction Battery --query "battery RUL transformer" --top 10
 python scripts/web_search.py find --direction Battery --source arxiv --arxiv-id 2502.18807v7 --fulltext
 ```
-

--- a/paper-wiki/references/workflows/10-web-digest.md
+++ b/paper-wiki/references/workflows/10-web-digest.md
@@ -5,36 +5,230 @@
 
 ## Workflow 10: web-digest
 
-> **Status**: Implemented (CLI fail-fast; Agent may bootstrap missing direction)
+> **Status**: Implemented (MCP-first with CLI fallback)
 
 ### Purpose
+
 Fetch recent arXiv papers for a direction and save them as Markdown sources plus a digest report.
 
 ### Input
+
 - Required: `--direction {existing_direction}`
 - Required: `--query "topic"`
 - Optional: `--top N`, `--no-domain-filter`, `--show-filtered`, `--dry-run`
 
+### MCP Integration
+
+This workflow uses a **MCP-first** strategy with CLI fallback:
+
+| Priority | Layer | Provider | Use Case |
+|:---:|:---|:---|:---|
+| 1 | arXiv Deep | `arxiv-mcp-server` | Recent arXiv search, full-text extraction, alerts |
+| 2 | Discovery Fallback | `paper-search-mcp` | arXiv search when arxiv-mcp-server unavailable |
+| 3 | CLI Fallback | `web_search.py` CLI | Direct HTTP API when MCP unavailable |
+
+**MCP Tool Reference**:
+
+| MCP Server | Tool Name | Purpose |
+|:---|:---|:---|
+| `arxiv-mcp-server` | `mcp__arxiv__search_papers` | arXiv search with date sorting |
+| `arxiv-mcp-server` | `mcp__arxiv__watch_topic` | Register topic for alert monitoring |
+| `arxiv-mcp-server` | `mcp__arxiv__check_alerts` | Check new papers since last check |
+| `arxiv-mcp-server` | `mcp__arxiv__download_paper` | Download arXiv full text |
+| `paper-search-mcp` | `mcp__paper-search-mcp__search_arxiv` | arXiv search fallback |
+
 ### Steps
 
-1. CLI behavior: validate that `paper/{direction}/` already exists. If missing, `web_search.py` fail-fast with guidance to create the direction before running `web-digest`.
-2. Agent recovery branch for a missing direction:
-   - reuse the same bootstrap flow as `web-find`
-   - analyze the query and existing direction/profile context
-   - offer two direction options and wait for user confirmation
-   - after confirmation, create the direction folders and config/profile stub, then rerun `web-digest`
-3. Build a profile-aware arXiv query from `web_search.domain_profiles.{direction}`
-4. Query arXiv by submitted date
-5. Apply the same domain filter and ranking path used by `web-find`
-6. Save arXiv full-text successes to `paper/{direction}/arxiv/`
-7. Use the same `html > tex > pdf > api` fallback as `web-find`
-8. Save PDF-only, abstract-only, and failed fallback records to `paper/web_search/{direction}/arxiv/`
-9. Generate canonical pages and rebuild indexes only when a full-text arXiv paper entered the formal library
-10. Generate digest report at `library/reports/web/{date}-{direction}-digest.md`, including filtered-out candidates
-11. Log the operation
+#### Step 1: Parse inputs and check MCP availability
 
-### Command
+1. Parse input arguments: `--direction`, `--query`, `--top`
+2. Load `config.json` and check `mcp.enabled` setting
+3. Check MCP server availability:
+   - `arxiv-mcp-server` (primary for digest)
+   - `paper-search-mcp` (fallback)
+4. If both MCP servers unavailable and `mcp.fallback_to_cli=true`, proceed to CLI fallback path
+
+#### Step 2: CLI direction validation
+
+CLI behavior: validate that `paper/{direction}/` already exists. If missing, `web_search.py` fail-fast with guidance to create the direction before running `web-digest`.
+
+Agent recovery branch for a missing direction:
+- reuse the same bootstrap flow as `web-find`
+- analyze the query and existing direction/profile context
+- offer two direction options and wait for user confirmation
+- after confirmation, create the direction folders and config/profile stub, then rerun `web-digest`
+
+#### Step 3: Build arXiv query
+
+Build a profile-aware arXiv query from:
+- `config.web_search.domain_profiles.{direction}` keywords
+- `config.web_digest.lookback_days` for date range
+- `config.web_search.domain_profiles.{direction}.arxiv_categories` for category filter
+
+Query components:
+- Base query: `--query` argument
+- Category filter: from `arxiv_categories` (if defined)
+- Date filter: `date_from = today - lookback_days`
+
+#### Step 4: Query recent arXiv papers via MCP
+
+**Primary**: `mcp__arxiv__search_papers`
+
+Call parameters:
+```json
+{
+  "query": "<constructed_query>",
+  "max_results": <top>,
+  "sort_by": "date",
+  "date_from": "<lookback_date>",
+  "categories": ["<from arxiv_categories>"]
+}
+```
+
+Sort configuration:
+- MCP parameter `sort_by="date"` corresponds to config `web_digest.sort_by="submittedDate"`
+- Sort by date ensures newest papers first
+
+#### Step 5: Optional alert mode
+
+If `config.web_digest.use_alerts=true`:
+
+**Step 5A**: Register topic watch via `mcp__arxiv__watch_topic`
+```json
+{
+  "topic": "<query>",
+  "categories": ["<arxiv_categories>"],
+  "max_results": <top>
+}
+```
+
+**Step 5B**: Check for new papers via `mcp__arxiv__check_alerts`
+```json
+{}
+```
+
+Alert mode returns only papers published since last check, enabling incremental digest without re-querying all recent papers.
+
+Default behavior: stateless search (matches current web-digest functionality).
+
+#### Step 6: Fulltext decision
+
+Evaluate whether to download full text:
+
+| Condition | Download? | Config Key |
+|:---|:---:|:---|
+| Default digest | No (abstract only) | `mcp.arxiv.download_fulltext.digest` (default: false) |
+| `--fulltext` flag | Yes | Overrides config |
+
+Digest typically saves metadata + abstract only for efficiency.
+
+If fulltext enabled:
+- Cap downloads by `config.mcp.arxiv.download_fulltext.max_fulltext_per_run` (default: 5)
+- Format priority: `config.mcp.arxiv.content_priority` (default: `["html", "tex", "pdf"]`)
+
+Call `mcp__arxiv__download_paper` for selected papers:
+```json
+{
+  "paper_id": "<arxiv_id>"
+}
+```
+
+#### Step 7: Apply domain filter
+
+Apply the same domain filter used by `web-find`:
+- Evaluate each candidate against `config.domain_profiles.{direction}`
+- Strict profiles require all configured `required_groups`
+- Reject papers with strong `negative_keywords` hits
+- Save only accepted candidates unless `--no-domain-filter` is set
+
+#### Step 8: Save results
+
+Save paths:
+- Full text extracted → `paper/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
+- Metadata/abstract only → `paper/web_search/{direction}/arxiv/{year}-{first_author}-{title_slug}-{arxiv_id}.md`
+
+Add MCP provenance to frontmatter:
+```yaml
+---
+# ... existing fields ...
+mcp_provider: "arxiv-mcp-server"
+mcp_tool: "search_papers" | "download_paper"
+retrieved_at: <ISO timestamp>
+retrieval_path: "mcp" | "cli_fallback"
+---
+```
+
+Generate canonical pages only when a full-text arXiv paper entered the formal library:
+- Call `generate_canonical` for each full-text save
+- Rebuild indexes via `rebuild_indexes.py`
+
+#### Step 9: Generate digest report
+
+Generate digest report at:
+- `library/reports/web/{date}-{direction}-digest.md`
+
+Report sections:
+1. Summary: papers found, date range, categories, MCP status
+2. Recent arXiv Papers: table with title, authors, submitted date, arXiv link, abstract summary
+3. Full Text Downloads: list of papers with extracted full text
+4. Filtered-out candidates: list with rejection reasons
+5. MCP status: server used, any fallback events
+6. Installation suggestion (if MCP unavailable)
+
+Include `filtered_out` candidates for auditability.
+
+#### Step 10: Log and manifest
+
+Write manifest:
+- `workspace/manifests/arxiv_fulltext_results.json` (if any full text downloaded)
+- `workspace/manifests/web_search_results.json` (metadata only)
+
+Log operation to `workspace/logs/web_search.md`
+
+#### Step 11: CLI fallback path
+
+If MCP servers unavailable, execute CLI fallback:
+
+```bash
+python scripts/web_search.py digest --direction {direction} --query "{query}" --top {top}
+```
+
+CLI behavior (unchanged from legacy):
+1. Validate `paper/{direction}/` exists
+2. Direct HTTP request to arXiv API with date sorting
+3. Apply domain filter and save to same directory structure
+4. Generate same digest report format
+
+At workflow completion, if CLI was used due to MCP unavailable:
+- Output suggestion: "建议安装 MCP 服务器以增强网络搜索功能：arxiv-mcp-server 和 paper-search-mcp。详见 config.json 中的 mcp 配置说明。"
+
+#### Step 12: Fallback chain
+
+**Fallback rule**: CLI fallback is allowed only when `config.mcp.fallback_to_cli=true` AND one of the fallback triggers occurs.
+
+MCP fallback order (trigger conditions):
+1. **Primary**: `arxiv-mcp-server.search_papers` (with date sort)
+2. **Secondary**: `mcp__paper-search-mcp__search_arxiv` (with `sort_by="submittedDate"`)
+3. **CLI**: `web_search.py digest`
+
+**Fallback triggers**:
+- MCP server unavailable (not connected)
+- MCP tool call timeout or error
+- `config.mcp.enabled=false`
+
+**No fallback**:
+- Valid empty result (no new papers matching query) - unless `config.mcp.fallback_on_empty=true`
+- `config.mcp.fallback_to_cli=false` - do not use CLI fallback
+
+### Command Reference
+
+**MCP path (Agent)**:
+```
+# MCP tools called per above steps
+web-digest --direction Battery --query "battery health prognosis" --top 10
+```
+
+**CLI path**:
 ```bash
 python scripts/web_search.py digest --direction Battery --query "battery health prognosis" --top 10
 ```
-


### PR DESCRIPTION
 ### Summary
  Integrated two MCP servers (arxiv-mcp-server and paper-search-mcp) into web-find and web-digest workflows, enabling more
  powerful academic paper discovery and arXiv deep processing capabilities.

  ### Changes

  #### SKILL.md
  - Added MCP-first web search routing note
  - Documented fallback strategy: MCP → CLI
  - Added installation suggestion guideline

  #### references/workflows/09-web-find.md
  - Reimplemented with MCP-first architecture (11 steps)
  - Added intent-based routing: --arxiv-id, --source=arxiv/mixed/openalex/semantic
  - Integrated paper-search-mcp for broad discovery
  - Integrated arxiv-mcp-server for arXiv deep processing
  - Added fulltext decision logic with config control
  - Documented CLI fallback triggers and conditions

  #### references/workflows/10-web-digest.md
  - Reimplemented with MCP-first architecture (12 steps)
  - Added arxiv-mcp-server as primary for recent arXiv search
  - Added alert mode support (watch_topic/check_alerts)
  - Added paper-search-mcp as fallback
  - Documented fallback chain with clear trigger conditions

  #### references/configuration.md
  - Added complete `mcp.*` configuration section
  - Added `mcp.enabled`, `mcp.fallback_to_cli`, `mcp.fallback_on_empty`
  - Added `mcp.paper_search.enabled`, `mcp.paper_search.broad_sources`
  - Added `mcp.arxiv.enabled`, `mcp.arxiv.content_priority`
  - Added `mcp.arxiv.download_fulltext.*` with 4 modes (exact_id, source_arxiv, mixed, digest)
  - Added `max_fulltext_per_run` cap
  - Added `domain_profiles.{direction}.arxiv_categories` field
  - Added MCP server installation guide with official repo links

  ### Architecture
  - Layer 1: paper-search-mcp (broad multi-source discovery)
  - Layer 2: arxiv-mcp-server (arXiv deep processing, fulltext, alerts)
  - Layer 3: CLI fallback (direct HTTP API when MCP unavailable)

  ### MCP Servers
  - arxiv-mcp-server: https://github.com/blazickjp/arxiv-mcp-server
  - paper-search-mcp: https://github.com/openags/paper-search-mcp